### PR TITLE
Ocaml 4.03

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -5,3 +5,4 @@ PKG lwt
 PKG lwt.ppx
 PKG cohttp.lwt
 PKG yojson
+PKG ppx_deriving_yojson

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: true
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
+sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
   global:
@@ -11,4 +11,4 @@ env:
   matrix:
     - OCAML_VERSION=4.02
     - OCAML_VERSION=4.03
-    - OCAML_VERSION=latest
+    - OCAML_VERSION=4.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
+sudo: true
 language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.02 PACKAGE=slacko EXTRA_DEPS="oasis" PRE_INSTALL_HOOK="oasis setup" TESTS=false
+  global:
+    - PACKAGE=slacko
+    - EXTRA_DEPS="oasis"
+    - PRE_INSTALL_HOOK="oasis setup"
+    - TESTS=false
+  matrix:
+    - OCAML_VERSION=4.02
+    - OCAML_VERSION=4.03

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ env:
   matrix:
     - OCAML_VERSION=4.02
     - OCAML_VERSION=4.03
+    - OCAML_VERSION=latest

--- a/opam
+++ b/opam
@@ -28,6 +28,10 @@ depends: [
   "oasis" {build & >= "0.4.0"}
   # /development
 ]
+conflicts: [
+  # broken release: https://github.com/mirage/ocaml-conduit/issues/189
+  "conduit" {= "0.14.1"}
+]
 dev-repo: "git://github.com/Leonidas-from-XIV/slacko"
 bug-reports: "https://github.com/Leonidas-from-XIV/slacko/issues"
 available: [ ocaml-version >= "4.02.0" ]

--- a/opam
+++ b/opam
@@ -23,7 +23,7 @@ depends: [
   "lwt" {>= "2.4.7"}
   "tls" | "ssl"
   "cohttp" {>= "0.13.0"}
-  "ppx_deriving_yojson" {>= "2.3"}
+  "ppx_deriving_yojson" {>= "3.0"}
   # for development. Not to be included in opam-repository
   "oasis" {build & >= "0.4.0"}
   # /development

--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -201,30 +201,30 @@ let timestamp_to_yojson ts =
   `Int (int_of_float ts)
 
 let timestamp_of_yojson = function
-  | `Int x -> Ok (float_of_int x)
-  | `Intlit x -> Ok (float_of_string x)
-  | `String x -> Ok (float_of_string x)
-  | _ -> Error "Couldn't parse timestamp type"
+  | `Int x -> Result.Ok (float_of_int x)
+  | `Intlit x -> Result.Ok (float_of_string x)
+  | `String x -> Result.Ok (float_of_string x)
+  | _ -> Result.Error "Couldn't parse timestamp type"
 
 let user_of_yojson = function
-  | `String x -> Ok (UserId x)
-  | _ -> Error "Couldn't parse user type"
+  | `String x -> Result.Ok (UserId x)
+  | _ -> Result.Error "Couldn't parse user type"
 
 let channel_of_yojson = function
-  | `String x -> Ok (ChannelId x)
-  | _ -> Error "Couldn't parse channel type"
+  | `String x -> Result.Ok (ChannelId x)
+  | _ -> Result.Error "Couldn't parse channel type"
 
 let group_of_yojson = function
-  | `String x -> Ok (GroupId x)
-  | _ -> Error "Couldn't parse group type"
+  | `String x -> Result.Ok (GroupId x)
+  | _ -> Result.Error "Couldn't parse group type"
 
 let conversation_of_yojson = function
-  | `String x -> Ok x
-  | _ -> Error "Couldn't parse conversation type"
+  | `String x -> Result.Ok x
+  | _ -> Result.Error "Couldn't parse conversation type"
 
 let token_of_yojson = function
-  | `String x -> Ok x
-  | _ -> Error "Couldn't parse token"
+  | `String x -> Result.Ok x
+  | _ -> Result.Error "Couldn't parse token"
 
 type topic_obj = {
   value: string;
@@ -370,11 +370,11 @@ type channel_rename_obj = {
 
 let chat_of_yojson = function
   | `String c -> (match c.[0] with
-    | 'C' -> Ok (Channel (ChannelId c))
-    | 'D' -> Ok (Im c)
-    | 'G' -> Ok (Group (GroupId c))
-    | _ -> Error "Failed to parse chat")
-  | _ -> Error "Failed to parse chat"
+    | 'C' -> Result.Ok (Channel (ChannelId c))
+    | 'D' -> Result.Ok (Im c)
+    | 'G' -> Result.Ok (Group (GroupId c))
+    | _ -> Result.Error "Failed to parse chat")
+  | _ -> Result.Error "Failed to parse chat"
 
 type chat_obj = {
   ts: timestamp;
@@ -540,8 +540,8 @@ type api_answer = {
 
 let validate json =
   match api_answer_of_yojson json with
-  | Error str -> `ParseFailure str
-  | Ok parsed -> match parsed.ok, parsed.error with
+  | Result.Error str -> `ParseFailure str
+  | Result.Ok parsed -> match parsed.ok, parsed.error with
     | true, _ -> `Json_response json
     | _, Some "account_inactive" -> `Account_inactive
     | _, Some "already_archived" -> `Already_archived
@@ -659,8 +659,8 @@ let channels_list ?exclude_archived token =
     >|= function
     | `Json_response d ->
       (match d |> channels_list_obj_of_yojson with
-        | Ok x -> `Success x.channels
-        | Error x -> `ParseFailure x)
+        | Result.Ok x -> `Success x.channels
+        | Result.Error x -> `ParseFailure x)
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
@@ -671,8 +671,8 @@ let users_list token =
     >|= function
     | `Json_response d ->
       (match d |> users_list_obj_of_yojson with
-        | Ok x -> `Success x.members
-        | Error x -> `ParseFailure x)
+        | Result.Ok x -> `Success x.members
+        | Result.Error x -> `ParseFailure x)
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
@@ -684,8 +684,8 @@ let groups_list ?exclude_archived token =
     >|= function
     | `Json_response d ->
       (match d |> groups_list_obj_of_yojson with
-        | Ok x -> `Success x.groups
-        | Error x -> `ParseFailure x)
+        | Result.Ok x -> `Success x.groups
+        | Result.Error x -> `ParseFailure x)
     | #bot_error
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
@@ -811,8 +811,8 @@ let conversation_of_string s =
   if s.[0] = 'D' then s else failwith "Not an IM channel"
 
 let translate_parsing_error = function
-  | Error a -> `ParseFailure a
-  | Ok a -> `Success a
+  | Result.Error a -> `ParseFailure a
+  | Result.Ok a -> `Success a
 
 (* Slack API begins here *)
 
@@ -1122,8 +1122,8 @@ let emoji_list token =
     >|= function
     | `Json_response d ->
       (match d |> emoji_list_obj_of_yojson with
-      | Ok x -> `Success x.emoji
-      | Error x -> `ParseFailure x)
+      | Result.Ok x -> `Success x.emoji
+      | Result.Error x -> `ParseFailure x)
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
@@ -1455,8 +1455,8 @@ let im_list token =
     >|= function
     | `Json_response d ->
       (match d |> im_list_obj_of_yojson with
-        | Ok x -> `Success x.ims
-        | Error x -> `ParseFailure x)
+        | Result.Ok x -> `Success x.ims
+        | Result.Error x -> `ParseFailure x)
     | #bot_error
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error

--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -201,30 +201,30 @@ let timestamp_to_yojson ts =
   `Int (int_of_float ts)
 
 let timestamp_of_yojson = function
-  | `Int x -> `Ok (float_of_int x)
-  | `Intlit x -> `Ok (float_of_string x)
-  | `String x -> `Ok (float_of_string x)
-  | _ -> `Error "Couldn't parse timestamp type"
+  | `Int x -> Ok (float_of_int x)
+  | `Intlit x -> Ok (float_of_string x)
+  | `String x -> Ok (float_of_string x)
+  | _ -> Error "Couldn't parse timestamp type"
 
 let user_of_yojson = function
-  | `String x -> `Ok (UserId x)
-  | _ -> `Error "Couldn't parse user type"
+  | `String x -> Ok (UserId x)
+  | _ -> Error "Couldn't parse user type"
 
 let channel_of_yojson = function
-  | `String x -> `Ok (ChannelId x)
-  | _ -> `Error "Couldn't parse channel type"
+  | `String x -> Ok (ChannelId x)
+  | _ -> Error "Couldn't parse channel type"
 
 let group_of_yojson = function
-  | `String x -> `Ok (GroupId x)
-  | _ -> `Error "Couldn't parse group type"
+  | `String x -> Ok (GroupId x)
+  | _ -> Error "Couldn't parse group type"
 
 let conversation_of_yojson = function
-  | `String x -> `Ok x
-  | _ -> `Error "Couldn't parse conversation type"
+  | `String x -> Ok x
+  | _ -> Error "Couldn't parse conversation type"
 
 let token_of_yojson = function
-  | `String x -> `Ok x
-  | _ -> `Error "Couldn't parse token"
+  | `String x -> Ok x
+  | _ -> Error "Couldn't parse token"
 
 type topic_obj = {
   value: string;
@@ -370,11 +370,11 @@ type channel_rename_obj = {
 
 let chat_of_yojson = function
   | `String c -> (match c.[0] with
-    | 'C' -> `Ok (Channel (ChannelId c))
-    | 'D' -> `Ok (Im c)
-    | 'G' -> `Ok (Group (GroupId c))
-    | _ -> `Error "Failed to parse chat")
-  | _ -> `Error "Failed to parse chat"
+    | 'C' -> Ok (Channel (ChannelId c))
+    | 'D' -> Ok (Im c)
+    | 'G' -> Ok (Group (GroupId c))
+    | _ -> Error "Failed to parse chat")
+  | _ -> Error "Failed to parse chat"
 
 type chat_obj = {
   ts: timestamp;
@@ -540,8 +540,8 @@ type api_answer = {
 
 let validate json =
   match api_answer_of_yojson json with
-  | `Error str -> `ParseFailure str
-  | `Ok parsed -> match parsed.ok, parsed.error with
+  | Error str -> `ParseFailure str
+  | Ok parsed -> match parsed.ok, parsed.error with
     | true, _ -> `Json_response json
     | _, Some "account_inactive" -> `Account_inactive
     | _, Some "already_archived" -> `Already_archived
@@ -659,8 +659,8 @@ let channels_list ?exclude_archived token =
     >|= function
     | `Json_response d ->
       (match d |> channels_list_obj_of_yojson with
-        | `Ok x -> `Success x.channels
-        | `Error x -> `ParseFailure x)
+        | Ok x -> `Success x.channels
+        | Error x -> `ParseFailure x)
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
@@ -671,8 +671,8 @@ let users_list token =
     >|= function
     | `Json_response d ->
       (match d |> users_list_obj_of_yojson with
-        | `Ok x -> `Success x.members
-        | `Error x -> `ParseFailure x)
+        | Ok x -> `Success x.members
+        | Error x -> `ParseFailure x)
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
@@ -684,8 +684,8 @@ let groups_list ?exclude_archived token =
     >|= function
     | `Json_response d ->
       (match d |> groups_list_obj_of_yojson with
-        | `Ok x -> `Success x.groups
-        | `Error x -> `ParseFailure x)
+        | Ok x -> `Success x.groups
+        | Error x -> `ParseFailure x)
     | #bot_error
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
@@ -811,8 +811,8 @@ let conversation_of_string s =
   if s.[0] = 'D' then s else failwith "Not an IM channel"
 
 let translate_parsing_error = function
-  | `Error a -> `ParseFailure a
-  | `Ok a -> `Success a
+  | Error a -> `ParseFailure a
+  | Ok a -> `Success a
 
 (* Slack API begins here *)
 
@@ -1122,8 +1122,8 @@ let emoji_list token =
     >|= function
     | `Json_response d ->
       (match d |> emoji_list_obj_of_yojson with
-      | `Ok x -> `Success x.emoji
-      | `Error x -> `ParseFailure x)
+      | Ok x -> `Success x.emoji
+      | Error x -> `ParseFailure x)
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
@@ -1455,8 +1455,8 @@ let im_list token =
     >|= function
     | `Json_response d ->
       (match d |> im_list_obj_of_yojson with
-        | `Ok x -> `Success x.ims
-        | `Error x -> `ParseFailure x)
+        | Ok x -> `Success x.ims
+        | Error x -> `ParseFailure x)
     | #bot_error
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error


### PR DESCRIPTION
This adds a Travis build for OCaml 4.03 (and also `latest`, which seems to still be `4.02`).

In order to build on 4.03 we need `ppx_deriving_yojson>=3.0`, which requires changes to the result type.

I also ~pinned `conduit` to 0.14.0~ added a `conflict` with `conduit` 0.14.1 because of https://github.com/mirage/ocaml-conduit/issues/189 which has been fixed but not yet released.