### PR TITLE
Session-based API

### DIFF
--- a/src/slack_notify.ml
+++ b/src/slack_notify.ml
@@ -18,6 +18,10 @@
 * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 *)
 
+let base_url =
+  let doc = "The Slack API base URL" in
+  Cmdliner.Arg.(value & opt (some string) None & info ["base-url"] ~docv:"URL" ~doc)
+
 let token =
   let doc = "The Slack API access token" in
   Cmdliner.Arg.(required & opt (some string) None & info ["t"; "token"] ~docv:"TOKEN" ~doc)
@@ -50,7 +54,7 @@ let info =
   let doc = "Posts messages to Slack" in
   Cmdliner.Term.info "slack-notify" ~doc
 
-let execute token username channel icon_url icon_emoji attachment_text msg =
+let execute base_url token username channel icon_url icon_emoji attachment_text msg =
   "Your token is " ^ token ^ ", the channel is " ^ channel
     ^ " and the message is '" ^ msg ^ "'."
     |> print_endline;
@@ -66,7 +70,7 @@ let execute token username channel icon_url icon_emoji attachment_text msg =
   in
 
   let open Lwt in
-  let token = Slacko.token_of_string token in
+  let session = Slacko.make_session ?base_url token in
   let channel = Slacko.channel_of_string channel in
   let chat = Slacko.Channel channel in
   let msg = Slacko.message_of_string msg in
@@ -75,7 +79,7 @@ let execute token username channel icon_url icon_emoji attachment_text msg =
     | None -> None
     | Some text -> Some [Slacko.attachment ~text ()]
   in
-  Slacko.chat_post_message token chat
+  Slacko.chat_post_message session chat
     ?username:(username)
     ?icon_emoji:(icon_emoji)
     ?icon_url:(icon_url)
@@ -86,7 +90,7 @@ let execute token username channel icon_url icon_emoji attachment_text msg =
   |> Lwt_main.run
 
 let execute_t = Cmdliner.Term.(
-    pure execute $ token $ username $ channel $ icon_url $ icon_emoji
+    pure execute $ base_url $ token $ username $ channel $ icon_url $ icon_emoji
     $ attachment $ message)
 
 let () =

--- a/src/slack_notify.ml
+++ b/src/slack_notify.ml
@@ -70,7 +70,7 @@ let execute base_url token username channel icon_url icon_emoji attachment_text 
   in
 
   let open Lwt in
-  let session = Slacko.make_session ?base_url token in
+  let session = Slacko.start_session ?base_url token in
   let channel = Slacko.channel_of_string channel in
   let chat = Slacko.Channel channel in
   let msg = Slacko.message_of_string msg in

--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -599,16 +599,16 @@ let optionally_add key value uri = match value with
 
 let definitely_add key value = optionally_add key (Some value)
 
-let unauthed_endpoint ~base_url meth =
+let unauthed_endpoint ~base_url method' =
   let base_url = match base_url with
     | None -> default_base_url
     | Some base_url -> base_url
   in
-  base_url ^ meth
+  base_url ^ method'
   |> Uri.of_string
 
-let endpoint meth session =
-  unauthed_endpoint ~base_url:(Some session.base_url) meth
+let endpoint method' session =
+  unauthed_endpoint ~base_url:(Some session.base_url) method'
   |> definitely_add "token" session.token
 
 (* private API return type *)
@@ -1550,8 +1550,8 @@ let oauth_access ?base_url client_id client_secret ?redirect_url code =
     | #oauth_error as res -> res
     | _ -> `Unknown_error
 
-let search meth session ?sort ?sort_dir ?highlight ?count ?page query_ =
-  endpoint meth session
+let search method' session ?sort ?sort_dir ?highlight ?count ?page query_ =
+  endpoint method' session
     |> definitely_add "query" @@ query_
     |> optionally_add "sort" @@ maybe string_of_criterion sort
     |> optionally_add "sort_dir" @@ maybe string_of_direction sort_dir

--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -599,16 +599,16 @@ let optionally_add key value uri = match value with
 
 let definitely_add key value = optionally_add key (Some value)
 
-let unauthed_endpoint ~base_url e =
+let unauthed_endpoint ~base_url meth =
   let base_url = match base_url with
     | None -> default_base_url
     | Some base_url -> base_url
   in
-  base_url ^ e
+  base_url ^ meth
   |> Uri.of_string
 
-let endpoint session e =
-  unauthed_endpoint ~base_url:(Some session.base_url) e
+let endpoint meth session =
+  unauthed_endpoint ~base_url:(Some session.base_url) meth
   |> definitely_add "token" session.token
 
 (* private API return type *)
@@ -734,7 +734,7 @@ type im_list_obj = {
 } [@@deriving of_yojson]
 
 let channels_list ?exclude_archived session =
-  endpoint session "channels.list"
+  endpoint "channels.list" session
     |> optionally_add "exclude_archived" @@ maybe string_of_bool @@ exclude_archived
     |> query
     >|= function
@@ -746,7 +746,7 @@ let channels_list ?exclude_archived session =
     | _ -> `Unknown_error
 
 let users_list session =
-  endpoint session "users.list"
+  endpoint "users.list" session
     |> query
     >|= function
     | `Json_response d ->
@@ -757,7 +757,7 @@ let users_list session =
     | _ -> `Unknown_error
 
 let groups_list ?exclude_archived session =
-  endpoint session "groups.list"
+  endpoint "groups.list" session
     |> optionally_add "exclude_archived" @@ maybe string_of_bool exclude_archived
     |> query
     >|= function
@@ -910,7 +910,7 @@ let api_test ?base_url ?foo ?error () =
     | _ -> `Unknown_error
 
 let auth_test session =
-  endpoint session "auth.test"
+  endpoint "auth.test" session
     |> query
     >|= function
     | `Json_response d -> d |> authed_obj_of_yojson |> translate_parsing_error
@@ -933,7 +933,7 @@ let (|+>) m f =
 
 let channels_archive session channel =
   id_of_channel session channel |-> fun channel_id ->
-    endpoint session "channels.archive"
+    endpoint "channels.archive" session
     |> definitely_add "channel" channel_id
     |> query
     >|= function
@@ -949,7 +949,7 @@ let channels_archive session channel =
     | _ -> `Unknown_error
 
 let channels_create session name =
-  endpoint session "channels.create"
+  endpoint "channels.create" session
     |> definitely_add "name" name
     |> query
     >|= function
@@ -964,7 +964,7 @@ let channels_create session name =
 let channels_history session
   ?latest ?oldest ?count ?inclusive channel =
   id_of_channel session channel |-> fun channel_id ->
-    endpoint session "channels.history"
+    endpoint "channels.history" session
     |> definitely_add "channel" channel_id
     |> optionally_add "latest" @@ maybe string_of_timestamp latest
     |> optionally_add "oldest" @@ maybe string_of_timestamp oldest
@@ -978,7 +978,7 @@ let channels_history session
 
 let channels_info session channel =
   id_of_channel session channel |-> fun channel_id ->
-    endpoint session "channels.info"
+    endpoint "channels.info" session
     |> definitely_add "channel" channel_id
     |> query
     >|= function
@@ -991,7 +991,7 @@ let channels_info session channel =
 let channels_invite session channel user =
   id_of_channel session channel |-> fun channel_id ->
   id_of_user session user |+> fun user_id ->
-    endpoint session "channels.invite"
+    endpoint "channels.invite" session
     |> definitely_add "channel" channel_id
     |> definitely_add "user" user_id
     |> query
@@ -1010,7 +1010,7 @@ let channels_invite session channel user =
     | _ -> `Unknown_error
 
 let channels_join session name =
-  endpoint session "channels.join"
+  endpoint "channels.join" session
     |> definitely_add "name" @@ string_of_channel name
     |> query
     >|= function
@@ -1027,7 +1027,7 @@ let channels_join session name =
 let channels_kick session channel user =
   id_of_channel session channel |-> fun channel_id ->
   id_of_user session user |+> fun user_id ->
-    endpoint session "channels.kick"
+    endpoint "channels.kick" session
     |> definitely_add "channel" channel_id
     |> definitely_add "user" user_id
     |> query
@@ -1045,7 +1045,7 @@ let channels_kick session channel user =
 
 let channels_leave session channel =
   id_of_channel session channel |-> fun channel_id ->
-  endpoint session "channels.leave"
+  endpoint "channels.leave" session
     |> definitely_add "channel" channel_id
     |> query
     >|= function
@@ -1061,7 +1061,7 @@ let channels_leave session channel =
 
 let channels_mark session channel ts =
   id_of_channel session channel |-> fun channel_id ->
-  endpoint session "channels.mark"
+  endpoint "channels.mark" session
     |> definitely_add "channel" channel_id
     |> definitely_add "ts" @@ string_of_timestamp ts
     |> query
@@ -1075,7 +1075,7 @@ let channels_mark session channel ts =
 
 let channels_rename session channel name =
   id_of_channel session channel |-> fun channel_id ->
-  endpoint session "channels.rename"
+  endpoint "channels.rename" session
     |> definitely_add "channel" channel_id
     |> definitely_add "name" name
     |> query
@@ -1094,7 +1094,7 @@ let channels_rename session channel name =
 
 let channels_set_purpose session channel purpose =
   id_of_channel session channel |-> fun channel_id ->
-  endpoint session "channels.setPurpose"
+  endpoint "channels.setPurpose" session
     |> definitely_add "channel" channel_id
     |> definitely_add "purpose" purpose
     |> query
@@ -1106,7 +1106,7 @@ let channels_set_purpose session channel purpose =
 
 let channels_set_topic session channel topic =
   id_of_channel session channel |-> fun channel_id ->
-  endpoint session "channels.setTopic"
+  endpoint "channels.setTopic" session
     |> definitely_add "channel" channel_id
     |> definitely_add "topic" topic
     |> query
@@ -1118,7 +1118,7 @@ let channels_set_topic session channel topic =
 
 let channels_unarchive session channel =
   id_of_channel session channel |-> fun channel_id ->
-  endpoint session "channels.unarchive"
+  endpoint "channels.unarchive" session
     |> definitely_add "channel" channel_id
     |> query
     >|= function
@@ -1132,7 +1132,7 @@ let channels_unarchive session channel =
 
 let chat_delete session ts chat =
   id_of_chat session chat |-> fun chat_id ->
-  endpoint session "chat.delete"
+  endpoint "chat.delete" session
     |> definitely_add "channel" chat_id
     |> definitely_add "ts" @@ string_of_timestamp ts
     |> query
@@ -1150,7 +1150,7 @@ let jsonify_attachments attachments =
 let chat_post_message session chat
   ?username ?parse ?icon_url ?icon_emoji ?(attachments=[]) text =
   id_of_chat session chat |-> fun chat_id ->
-  endpoint session "chat.postMessage"
+  endpoint "chat.postMessage" session
     |> definitely_add "channel" chat_id
     |> definitely_add "text" text
     |> optionally_add "username" username
@@ -1173,7 +1173,7 @@ let chat_post_message session chat
 
 let chat_update session ts chat text =
   id_of_chat session chat |-> fun chat_id ->
-  endpoint session "chat.update"
+  endpoint "chat.update" session
     |> definitely_add "channel" chat_id
     |> definitely_add "ts" @@ string_of_timestamp ts
     |> definitely_add "text" text
@@ -1189,7 +1189,7 @@ let chat_update session ts chat text =
     | _ -> `Unknown_error
 
 let emoji_list session =
-  endpoint session "emoji.list"
+  endpoint "emoji.list" session
     |> query
     >|= function
     | `Json_response d ->
@@ -1200,7 +1200,7 @@ let emoji_list session =
     | _ -> `Unknown_error
 
 let files_delete session file =
-  endpoint session "files.delete"
+  endpoint "files.delete" session
     |> definitely_add "file" file
     |> query
     >|= function
@@ -1212,7 +1212,7 @@ let files_delete session file =
     | _ -> `Unknown_error
 
 let files_info session ?count ?page file =
-  endpoint session "files.info"
+  endpoint "files.info" session
     |> definitely_add "file" file
     |> optionally_add "count" @@ maybe string_of_int count
     |> optionally_add "page" @@ maybe string_of_int page
@@ -1234,7 +1234,7 @@ let maybe_with_user session user f =
 
 let files_list ?user ?ts_from ?ts_to ?types ?count ?page session =
   maybe_with_user session user @@ fun user_id ->
-  endpoint session "files.list"
+  endpoint "files.list" session
     |> optionally_add "user" user_id
     |> optionally_add "ts_from" @@ maybe string_of_timestamp ts_from
     |> optionally_add "ts_to" @@ maybe string_of_timestamp ts_to
@@ -1253,7 +1253,7 @@ let files_list ?user ?ts_from ?ts_to ?types ?count ?page session =
 
 let files_upload session
   ?filetype ?filename ?title ?initial_comment ?channels content =
-  endpoint session "files.upload"
+  endpoint "files.upload" session
     |> optionally_add "filetype" filetype
     |> optionally_add "filename" filename
     |> optionally_add "title" title
@@ -1269,7 +1269,7 @@ let files_upload session
 
 let groups_archive session group =
   id_of_group session group |-> fun group_id ->
-  endpoint session "groups.archive"
+  endpoint "groups.archive" session
     |> definitely_add "channel" group_id
     |> query
     >|= function
@@ -1286,7 +1286,7 @@ let groups_archive session group =
 
 let groups_close session group =
   id_of_group session group |-> fun group_id ->
-  endpoint session "groups.close"
+  endpoint "groups.close" session
     |> definitely_add "channel" group_id
     |> query
     >|= function
@@ -1297,7 +1297,7 @@ let groups_close session group =
     | _ -> `Unknown_error
 
 let groups_create session name =
-  endpoint session "groups.create"
+  endpoint "groups.create" session
     |> definitely_add "name" @@ name_of_group name
     |> query
     >|= function
@@ -1312,7 +1312,7 @@ let groups_create session name =
 
 let groups_create_child session group =
   id_of_group session group |-> fun group_id ->
-  endpoint session "groups.createChild"
+  endpoint "groups.createChild" session
     |> definitely_add "channel" group_id
     |> query
     >|= function
@@ -1328,7 +1328,7 @@ let groups_create_child session group =
 
 let groups_history session ?latest ?oldest ?count ?inclusive group =
   id_of_group session group |-> fun group_id ->
-  endpoint session "groups.history"
+  endpoint "groups.history" session
     |> definitely_add "channel" group_id
     |> optionally_add "latest" @@ maybe string_of_timestamp latest
     |> optionally_add "oldest" @@ maybe string_of_timestamp oldest
@@ -1343,7 +1343,7 @@ let groups_history session ?latest ?oldest ?count ?inclusive group =
 let groups_invite session group user =
   id_of_group session group |-> fun group_id ->
   id_of_user session user |+> fun user_id ->
-  endpoint session "groups.invite"
+  endpoint "groups.invite" session
     |> definitely_add "channel" group_id
     |> definitely_add "user" user_id
     |> query
@@ -1362,7 +1362,7 @@ let groups_invite session group user =
 let groups_kick session group user =
   id_of_group session group |-> fun group_id ->
   id_of_user session user |+> fun user_id ->
-  endpoint session "groups.kick"
+  endpoint "groups.kick" session
     |> definitely_add "channel" group_id
     |> definitely_add "user" user_id
     |> query
@@ -1380,7 +1380,7 @@ let groups_kick session group user =
 
 let groups_leave session group =
   id_of_group session group |-> fun group_id ->
-  endpoint session "groups.leave"
+  endpoint "groups.leave" session
     |> definitely_add "channel" group_id
     |> query
     >|= function
@@ -1396,7 +1396,7 @@ let groups_leave session group =
 
 let groups_mark session group ts =
   id_of_group session group |-> fun group_id ->
-  endpoint session "groups.mark"
+  endpoint "groups.mark" session
     |> definitely_add "channel" group_id
     |> definitely_add "ts" @@ string_of_timestamp ts
     |> query
@@ -1410,7 +1410,7 @@ let groups_mark session group ts =
 
 let groups_open session group =
   id_of_group session group |-> fun group_id ->
-  endpoint session "groups.open"
+  endpoint "groups.open" session
     |> definitely_add "channel" group_id
     |> query
     >|= function
@@ -1422,7 +1422,7 @@ let groups_open session group =
 
 let groups_rename session group name =
   id_of_group session group |-> fun group_id ->
-  endpoint session "groups.rename"
+  endpoint "groups.rename" session
     |> definitely_add "channel" group_id
     |> definitely_add "name" name
     |> query
@@ -1439,7 +1439,7 @@ let groups_rename session group name =
 
 let groups_set_purpose session group purpose =
   id_of_group session group |-> fun group_id ->
-  endpoint session "groups.setPurpose"
+  endpoint "groups.setPurpose" session
     |> definitely_add "channel" group_id
     |> definitely_add "purpose" purpose
     |> query
@@ -1451,7 +1451,7 @@ let groups_set_purpose session group purpose =
 
 let groups_set_topic session group topic =
   id_of_group session group |-> fun group_id ->
-  endpoint session "groups.setTopic"
+  endpoint "groups.setTopic" session
     |> definitely_add "channel" group_id
     |> definitely_add "topic" topic
     |> query
@@ -1463,7 +1463,7 @@ let groups_set_topic session group topic =
 
 let groups_unarchive session group =
   id_of_group session group |-> fun group_id ->
-  endpoint session "groups.unarchive"
+  endpoint "groups.unarchive" session
     |> definitely_add "channel" group_id
     |> query
     >|= function
@@ -1476,7 +1476,7 @@ let groups_unarchive session group =
     | _ -> `Unknown_error
 
 let im_close session channel =
-  endpoint session "im.close"
+  endpoint "im.close" session
     |> definitely_add "channel" channel
     |> query
     >|= function
@@ -1488,7 +1488,7 @@ let im_close session channel =
     | _ -> `Unknown_error
 
 let im_history session ?latest ?oldest ?count ?inclusive channel =
-  endpoint session "im.history"
+  endpoint "im.history" session
     |> definitely_add "channel" channel
     |> optionally_add "latest" @@ maybe string_of_timestamp latest
     |> optionally_add "oldest" @@ maybe string_of_timestamp oldest
@@ -1501,7 +1501,7 @@ let im_history session ?latest ?oldest ?count ?inclusive channel =
     | _ -> `Unknown_error
 
 let im_list session =
-  endpoint session "im.list"
+  endpoint "im.list" session
     |> query
     >|= function
     | `Json_response d ->
@@ -1513,7 +1513,7 @@ let im_list session =
     | _ -> `Unknown_error
 
 let im_mark session channel ts =
-  endpoint session "im.mark"
+  endpoint "im.mark" session
     |> definitely_add "channel" channel
     |> definitely_add "ts" @@ string_of_timestamp ts
     |> query
@@ -1526,7 +1526,7 @@ let im_mark session channel ts =
 
 let im_open session user =
   id_of_user session user |+> fun user_id ->
-  endpoint session "im.open"
+  endpoint "im.open" session
     |> definitely_add "user" user_id
     |> query
     >|= function
@@ -1550,9 +1550,9 @@ let oauth_access ?base_url client_id client_secret ?redirect_url code =
     | #oauth_error as res -> res
     | _ -> `Unknown_error
 
-let search session base ?sort ?sort_dir ?highlight ?count ?page query_ =
-  base
-    |> definitely_add "query" query_
+let search meth session ?sort ?sort_dir ?highlight ?count ?page query_ =
+  endpoint meth session
+    |> definitely_add "query" @@ query_
     |> optionally_add "sort" @@ maybe string_of_criterion sort
     |> optionally_add "sort_dir" @@ maybe string_of_direction sort_dir
     |> optionally_add "highlight" @@ maybe string_of_bool highlight
@@ -1566,13 +1566,13 @@ let search session base ?sort ?sort_dir ?highlight ?count ?page query_ =
     | #bot_error as res -> res
     | _ -> `Unknown_error
 
-let search_all session = search session @@ endpoint session "search.all"
-let search_files session = search session @@ endpoint session "search.files"
-let search_messages session = search session @@ endpoint session "search.messages"
+let search_all = search "search.all"
+let search_files = search "search.files"
+let search_messages = search "search.messages"
 
 let stars_list ?user ?count ?page session =
   maybe_with_user session user @@ fun user_id ->
-  endpoint session "stars.list"
+  endpoint "stars.list" session
     |> optionally_add "user" user_id
     |> optionally_add "count" @@ maybe string_of_int count
     |> optionally_add "page" @@ maybe string_of_int page
@@ -1586,7 +1586,7 @@ let stars_list ?user ?count ?page session =
     | _ -> `Unknown_error
 
 let team_access_logs ?count ?page session =
-  endpoint session "team.accessLogs"
+  endpoint "team.accessLogs" session
     |> optionally_add "count" @@ maybe string_of_int count
     |> optionally_add "page" @@ maybe string_of_int page
     |> query
@@ -1599,7 +1599,7 @@ let team_access_logs ?count ?page session =
     | _ -> `Unknown_error
 
 let team_info session =
-  endpoint session "team.info"
+  endpoint "team.info" session
     |> query
     >|= function
     | `Json_response d ->
@@ -1610,7 +1610,7 @@ let team_info session =
 
 let users_get_presence session user =
   id_of_user session user |+> fun user_id ->
-  endpoint session "users.getPresence"
+  endpoint "users.getPresence" session
     |> definitely_add "user" user_id
     |> query
     >|= function
@@ -1625,7 +1625,7 @@ let users_get_presence session user =
 let users_info session user =
   id_of_user session user
   |+> fun user_id ->
-  endpoint session "users.info"
+  endpoint "users.info" session
     |> definitely_add "user" user_id
     |> query
     >|= function
@@ -1637,7 +1637,7 @@ let users_info session user =
     | _ -> `Unknown_error
 
 let users_set_active session =
-  endpoint session "users.setActive"
+  endpoint "users.setActive" session
     |> query
     >|= function
     | `Json_response (`Assoc []) -> `Success
@@ -1646,7 +1646,7 @@ let users_set_active session =
     | _ -> `Unknown_error
 
 let users_set_presence session presence =
-  endpoint session "users.setPresence"
+  endpoint "users.setPresence" session
     |> definitely_add "presence" @@ string_of_presence presence
     |> query
     >|= function

--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -845,11 +845,11 @@ let string_of_presence = function
   | Away -> "away"
 
 (* Slacko API helper methods *)
-let make_session ?(base_url=default_base_url) token = {
+let start_session ?(base_url=default_base_url) token = {
   base_url;
   token;
 }
-let token_of_string token = make_session token
+let token_of_string token = start_session token
 let message_of_string = identity
 
 (* Calculate the amount of codepoints in a string encoded in UTF-8 *)

--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -599,12 +599,16 @@ let optionally_add key value uri = match value with
 
 let definitely_add key value = optionally_add key (Some value)
 
-let unauthed_endpoint ?(base_url=default_base_url) e =
+let unauthed_endpoint ~base_url e =
+  let base_url = match base_url with
+    | None -> default_base_url
+    | Some base_url -> base_url
+  in
   base_url ^ e
   |> Uri.of_string
 
 let endpoint session e =
-  unauthed_endpoint ~base_url:session.base_url e
+  unauthed_endpoint ~base_url:(Some session.base_url) e
   |> definitely_add "token" session.token
 
 (* private API return type *)
@@ -896,7 +900,7 @@ let translate_parsing_error = function
 (* Slack API begins here *)
 
 let api_test ?base_url ?foo ?error () =
-  unauthed_endpoint "api.test"
+  unauthed_endpoint ~base_url "api.test"
     |> optionally_add "foo" foo
     |> optionally_add "error" error
     |> query
@@ -1534,7 +1538,7 @@ let im_open session user =
     | _ -> `Unknown_error
 
 let oauth_access ?base_url client_id client_secret ?redirect_url code =
-  unauthed_endpoint ?base_url "oauth.access"
+  unauthed_endpoint ~base_url "oauth.access"
     |> definitely_add "client_id" client_id
     |> definitely_add "client_secret" client_secret
     |> definitely_add "code" code

--- a/src/slacko.mli
+++ b/src/slacko.mli
@@ -637,7 +637,8 @@ type history_result = [
 val start_session: ?base_url:string -> string -> session
 
 (** Deprecated wrapper for backcompat. *)
-val token_of_string: string -> session [@@ocaml.deprecated]
+val token_of_string: string -> session
+[@@ocaml.deprecated "Please use 'start_session' instead."]
 
 val field: ?title:string -> ?short:bool -> string -> field_obj
 

--- a/src/slacko.mli
+++ b/src/slacko.mli
@@ -634,10 +634,10 @@ type history_result = [
     functions. *)
 
 (** Create a session from a token string and an optional base_url. *)
-val make_session: ?base_url:string -> string -> session
+val start_session: ?base_url:string -> string -> session
 
 (** Deprecated wrapper for backcompat. *)
-val token_of_string: string -> session
+val token_of_string: string -> session [@@ocaml.deprecated]
 
 val field: ?title:string -> ?short:bool -> string -> field_obj
 

--- a/src/slacko.mli
+++ b/src/slacko.mli
@@ -23,7 +23,7 @@
 
     To use the API you first need to either apply for a {!token} from Slack,
     or get one via the OAuth2 API. This string can then be converted into
-    a {!token} by means of {!token_of_string}. With this {!token} most other
+    a {!session} by means of {!make_session}. With this {!session} most other
     methods from the binding can be called. The result of each API call is
     a variant type containing either the JSON result or an error type
     describing what kind of error occured.
@@ -48,8 +48,8 @@ type parsed_api_error = [
   | api_error
 ]
 
-(** API calls that require authentication (a {!token}) might fail with one of
-    these errors, so functions that take {!token} arguments will return
+(** API calls that require authentication (a {!session}) might fail with one of
+    these errors, so functions that take {!session} arguments will return
     {e at least} these error variants. *)
 type auth_error = [
   | `Not_authed
@@ -261,9 +261,11 @@ type topic_result = [
     can be used. *)
 type timestamp = float
 
-(** Tokens are required in the API for all actions that require
-    authentication. *)
-type token
+(** Sessions are required in the API for all actions that interact with
+     *)
+type session
+(** {!token} is an alias for {!session} for backwards compatibility reasons. *)
+type token = session
 
 (** The topic type represents a topic or a purpose message. Both are limited
     deliberately to have at most 250 UTF-8 encoded codepoints. *)
@@ -486,7 +488,7 @@ type im_open_obj = {
 (** When requesting an OAuth token, you get a token and the scope for which
     this token is valid. *)
 type oauth_obj = {
-  access_token: token;
+  access_token: string;
   scope: string;
 }
 
@@ -631,8 +633,11 @@ type history_result = [
 (** To build the types required in the API calls, you can use these helper
     functions. *)
 
-(** Converts a string into a token. *)
-val token_of_string: string -> token
+(** Create a session from a token string and an optional base_url. *)
+val make_session: ?base_url:string -> string -> session
+
+(** Deprecated wrapper for backcompat. *)
+val token_of_string: string -> session
 
 val field: ?title:string -> ?short:bool -> string -> field_obj
 
@@ -686,177 +691,178 @@ val conversation_of_string: string -> conversation
 (** {2 Slack API calls} *)
 
 (** Checks API calling code.
+    @param base_url If set, overrides the Slack API base URL.
     @param foo A dummy value that will be returned by the API.
     @param error If set, will return a specific kind of error. *)
-val api_test: ?foo:string -> ?error:string -> unit -> [ `Success of Yojson.Safe.json | api_error ] Lwt.t
+val api_test: ?base_url:string -> ?foo:string -> ?error:string -> unit -> [ `Success of Yojson.Safe.json | api_error ] Lwt.t
 
 (** Checks authentication & identity.
-    @param token The authentication token that was issued by Slack. *)
-val auth_test: token -> [ `Success of authed_obj | parsed_auth_error ] Lwt.t
+    @param session The session containing the authentication token. *)
+val auth_test: session -> [ `Success of authed_obj | parsed_auth_error ] Lwt.t
 
 (** Archives a channel. *)
-val channels_archive: token -> channel -> [ `Success | parsed_auth_error | channel_error | already_archived_error | `Cant_archive_general | `Last_restricted_channel | restriction_error | `User_is_restricted | bot_error ] Lwt.t
+val channels_archive: session -> channel -> [ `Success | parsed_auth_error | channel_error | already_archived_error | `Cant_archive_general | `Last_restricted_channel | restriction_error | `User_is_restricted | bot_error ] Lwt.t
 
 (** Creates a channel. *)
-val channels_create: token -> string -> [ `Success of channel_obj | parsed_auth_error | name_error | `User_is_restricted | bot_error ] Lwt.t
+val channels_create: session -> string -> [ `Success of channel_obj | parsed_auth_error | name_error | `User_is_restricted | bot_error ] Lwt.t
 
 (** Fetches history of messages and events from a channel.
-    @param token The authentication token that was issued by Slack.
+    @param session The session containing the authentication token.
     @param latest The newest message from history to be returned.
     @param oldest The oldest message from history to be returned.
     @param count The number of messages to be returned.
     @param inclusive Include messages with latest or oldest timestamp in results.
     @param channel The Slack channel from which to get the history. *)
-val channels_history: token -> ?latest:timestamp -> ?oldest:timestamp -> ?count:int -> ?inclusive:bool -> channel -> history_result Lwt.t
+val channels_history: session -> ?latest:timestamp -> ?oldest:timestamp -> ?count:int -> ?inclusive:bool -> channel -> history_result Lwt.t
 
 (** Gets information about a channel. *)
-val channels_info: token -> channel -> [ `Success of channel_obj | parsed_auth_error | channel_error ] Lwt.t
+val channels_info: session -> channel -> [ `Success of channel_obj | parsed_auth_error | channel_error ] Lwt.t
 
 (** Invites a user to a channel. *)
-val channels_invite: token -> channel -> user -> [ `Success of channel_obj | parsed_auth_error | channel_error | user_error | invite_error | not_in_channel_error | already_in_channel_error | archive_error | `User_is_ultra_restricted | bot_error ] Lwt.t
+val channels_invite: session -> channel -> user -> [ `Success of channel_obj | parsed_auth_error | channel_error | user_error | invite_error | not_in_channel_error | already_in_channel_error | archive_error | `User_is_ultra_restricted | bot_error ] Lwt.t
 
 (** Joins a channel, creating it if needed. *)
-val channels_join: token -> channel -> [ `Success of channel_obj | parsed_auth_error | channel_error | name_error | archive_error | `User_is_restricted | bot_error ] Lwt.t
+val channels_join: session -> channel -> [ `Success of channel_obj | parsed_auth_error | channel_error | name_error | archive_error | `User_is_restricted | bot_error ] Lwt.t
 
 (** Removes a user from a channel. *)
-val channels_kick: token -> channel -> user -> [ `Success | parsed_auth_error | channel_error | user_error | channel_kick_error | not_in_channel_error | restriction_error | `User_is_restricted | bot_error ] Lwt.t
+val channels_kick: session -> channel -> user -> [ `Success | parsed_auth_error | channel_error | user_error | channel_kick_error | not_in_channel_error | restriction_error | `User_is_restricted | bot_error ] Lwt.t
 
 (** Leaves a channel. *)
-val channels_leave: token -> channel -> [ `Success of channel_leave_obj | parsed_auth_error | channel_error | archive_error | leave_general_error | `User_is_restricted | bot_error ] Lwt.t
+val channels_leave: session -> channel -> [ `Success of channel_leave_obj | parsed_auth_error | channel_error | archive_error | leave_general_error | `User_is_restricted | bot_error ] Lwt.t
 
 (** Lists all channels in a Slack team. *)
-val channels_list: ?exclude_archived:bool -> token -> [ `Success of channel_obj list | parsed_auth_error ] Lwt.t
+val channels_list: ?exclude_archived:bool -> session -> [ `Success of channel_obj list | parsed_auth_error ] Lwt.t
 
 (** Sets the read cursor in a channel. *)
-val channels_mark: token -> channel -> timestamp -> [ `Success | parsed_auth_error | channel_error | archive_error | not_in_channel_error ] Lwt.t
+val channels_mark: session -> channel -> timestamp -> [ `Success | parsed_auth_error | channel_error | archive_error | not_in_channel_error ] Lwt.t
 
 (** Renames a team channel. *)
-val channels_rename: token -> channel -> string -> [ `Success of channel_rename_obj | parsed_auth_error | channel_error | not_in_channel_error | name_error | invalid_name_error | `Not_authorized | `User_is_restricted | bot_error ] Lwt.t
+val channels_rename: session -> channel -> string -> [ `Success of channel_rename_obj | parsed_auth_error | channel_error | not_in_channel_error | name_error | invalid_name_error | `Not_authorized | `User_is_restricted | bot_error ] Lwt.t
 
 (** Sets the purpose for a channel. *)
-val channels_set_purpose: token -> channel -> topic -> topic_result Lwt.t
+val channels_set_purpose: session -> channel -> topic -> topic_result Lwt.t
 
 (** Sets the topic for a channel. *)
-val channels_set_topic: token -> channel -> topic -> topic_result Lwt.t
+val channels_set_topic: session -> channel -> topic -> topic_result Lwt.t
 
 (** Unarchives a channel. *)
-val channels_unarchive: token -> channel -> [ `Success | parsed_auth_error | channel_error | `Not_archived | `User_is_restricted | bot_error ] Lwt.t
+val channels_unarchive: session -> channel -> [ `Success | parsed_auth_error | channel_error | `Not_archived | `User_is_restricted | bot_error ] Lwt.t
 
 (** Deletes a message. *)
-val chat_delete: token -> timestamp -> chat -> [ `Success of chat_obj | parsed_auth_error | channel_error | message_error ] Lwt.t
+val chat_delete: session -> timestamp -> chat -> [ `Success of chat_obj | parsed_auth_error | channel_error | message_error ] Lwt.t
 
 (** Sends a message to a channel. *)
-val chat_post_message: token -> chat -> ?username:string -> ?parse:string -> ?icon_url:string -> ?icon_emoji:string -> ?attachments:attachment_obj list -> message -> [ `Success of chat_obj | parsed_auth_error | channel_error | archive_error | message_length_error | attachments_error | rate_error | bot_error ] Lwt.t
+val chat_post_message: session -> chat -> ?username:string -> ?parse:string -> ?icon_url:string -> ?icon_emoji:string -> ?attachments:attachment_obj list -> message -> [ `Success of chat_obj | parsed_auth_error | channel_error | archive_error | message_length_error | attachments_error | rate_error | bot_error ] Lwt.t
 
 (** Updates a message. *)
-val chat_update: token -> timestamp -> chat -> message -> [ `Success of chat_obj | parsed_auth_error | channel_error | message_update_error | message_length_error | attachments_error ] Lwt.t
+val chat_update: session -> timestamp -> chat -> message -> [ `Success of chat_obj | parsed_auth_error | channel_error | message_update_error | message_length_error | attachments_error ] Lwt.t
 
 (** Lists custom emoji for a team. *)
-val emoji_list: token -> [ `Success of emoji list | parsed_auth_error ] Lwt.t
+val emoji_list: session -> [ `Success of emoji list | parsed_auth_error ] Lwt.t
 
-val files_delete: token -> string -> [ `Success | parsed_auth_error | `Cant_delete_file | file_error | bot_error ] Lwt.t
+val files_delete: session -> string -> [ `Success | parsed_auth_error | `Cant_delete_file | file_error | bot_error ] Lwt.t
 
 (** Gets information about a team file. *)
-val files_info: token -> ?count:int -> ?page:int -> string -> [ `Success of files_info_obj | parsed_auth_error | file_error | bot_error ] Lwt.t
+val files_info: session -> ?count:int -> ?page:int -> string -> [ `Success of files_info_obj | parsed_auth_error | file_error | bot_error ] Lwt.t
 
 (** Lists & filters team files. *)
-val files_list: ?user:user -> ?ts_from:timestamp -> ?ts_to:timestamp -> ?types:string -> ?count:int -> ?page:int -> token -> [ `Success of files_list_obj | parsed_auth_error | user_error | unknown_type_error | bot_error ] Lwt.t
+val files_list: ?user:user -> ?ts_from:timestamp -> ?ts_to:timestamp -> ?types:string -> ?count:int -> ?page:int -> session -> [ `Success of files_list_obj | parsed_auth_error | user_error | unknown_type_error | bot_error ] Lwt.t
 
 (** Uploads or creates a file. *)
-val files_upload: token -> ?filetype:string -> ?filename:string -> ?title:string -> ?initial_comment:string -> ?channels:string -> Cohttp_lwt_body.t -> [ `Success of file_obj | parsed_auth_error | bot_error ] Lwt.t
+val files_upload: session -> ?filetype:string -> ?filename:string -> ?title:string -> ?initial_comment:string -> ?channels:string -> Cohttp_lwt_body.t -> [ `Success of file_obj | parsed_auth_error | bot_error ] Lwt.t
 
 (** Archives a private group. *)
-val groups_archive: token -> group -> [ `Success | parsed_auth_error | channel_error | already_archived_error | `Group_contains_others | `Last_restricted_channel | restriction_error | `User_is_ultra_restricted | bot_error ] Lwt.t
+val groups_archive: session -> group -> [ `Success | parsed_auth_error | channel_error | already_archived_error | `Group_contains_others | `Last_restricted_channel | restriction_error | `User_is_ultra_restricted | bot_error ] Lwt.t
 
 (** Closes a private group. *)
-val groups_close: token -> group -> [ `Success of chat_close_obj | parsed_auth_error | channel_error ] Lwt.t
+val groups_close: session -> group -> [ `Success of chat_close_obj | parsed_auth_error | channel_error ] Lwt.t
 
 (** Creates a private group. *)
-val groups_create: token -> group -> [ `Success of group_obj | parsed_auth_error | name_error | restriction_error | `User_is_ultra_restricted | bot_error ] Lwt.t
+val groups_create: session -> group -> [ `Success of group_obj | parsed_auth_error | name_error | restriction_error | `User_is_ultra_restricted | bot_error ] Lwt.t
 
 (** Clones and archives a private group. *)
-val groups_create_child: token -> group -> [ `Success of group_obj | parsed_auth_error | channel_error | already_archived_error | restriction_error | `User_is_ultra_restricted | bot_error ] Lwt.t
+val groups_create_child: session -> group -> [ `Success of group_obj | parsed_auth_error | channel_error | already_archived_error | restriction_error | `User_is_ultra_restricted | bot_error ] Lwt.t
 
 (** Fetches history of messages and events from a private group. *)
-val groups_history: token -> ?latest:timestamp -> ?oldest:timestamp -> ?count:int -> ?inclusive:bool -> group -> history_result Lwt.t
+val groups_history: session -> ?latest:timestamp -> ?oldest:timestamp -> ?count:int -> ?inclusive:bool -> group -> history_result Lwt.t
 
 (** Invites a user to a private group. *)
-val groups_invite: token -> group -> user -> [ `Success of groups_invite_obj | parsed_auth_error | channel_error | user_error | invite_error | archive_error | `User_is_ultra_restricted | bot_error ] Lwt.t
+val groups_invite: session -> group -> user -> [ `Success of groups_invite_obj | parsed_auth_error | channel_error | user_error | invite_error | archive_error | `User_is_ultra_restricted | bot_error ] Lwt.t
 
 (** Removes a user from a private group. *)
-val groups_kick: token -> group -> user -> [ `Success | parsed_auth_error | channel_error | user_error | kick_error | not_in_group_error | restriction_error | `User_is_restricted | bot_error ] Lwt.t
+val groups_kick: session -> group -> user -> [ `Success | parsed_auth_error | channel_error | user_error | kick_error | not_in_group_error | restriction_error | `User_is_restricted | bot_error ] Lwt.t
 
 (** Leaves a private group. *)
-val groups_leave: token -> group -> [ `Success | parsed_auth_error | channel_error | archive_error | leave_last_channel_error | last_member_error | `User_is_ultra_restricted | bot_error ] Lwt.t
+val groups_leave: session -> group -> [ `Success | parsed_auth_error | channel_error | archive_error | leave_last_channel_error | last_member_error | `User_is_ultra_restricted | bot_error ] Lwt.t
 
 (** Lists private groups that the calling user has access to. *)
-val groups_list: ?exclude_archived:bool -> token -> [ `Success of group_obj list | parsed_auth_error | bot_error ] Lwt.t
+val groups_list: ?exclude_archived:bool -> session -> [ `Success of group_obj list | parsed_auth_error | bot_error ] Lwt.t
 
 (** Sets the read cursor in a private group. *)
-val groups_mark: token -> group -> timestamp -> [ `Success | parsed_auth_error | channel_error | archive_error | not_in_channel_error ] Lwt.t
+val groups_mark: session -> group -> timestamp -> [ `Success | parsed_auth_error | channel_error | archive_error | not_in_channel_error ] Lwt.t
 
 (** Opens a private group. *)
-val groups_open: token -> group -> [ `Success of groups_open_obj | parsed_auth_error | channel_error ] Lwt.t
+val groups_open: session -> group -> [ `Success of groups_open_obj | parsed_auth_error | channel_error ] Lwt.t
 
 (** Renames a private group. *)
-val groups_rename: token -> group -> string -> [ `Success of groups_rename_obj | parsed_auth_error | channel_error | name_error | invalid_name_error | `User_is_restricted | bot_error ] Lwt.t
+val groups_rename: session -> group -> string -> [ `Success of groups_rename_obj | parsed_auth_error | channel_error | name_error | invalid_name_error | `User_is_restricted | bot_error ] Lwt.t
 
 (** Sets the purpose for a private group. *)
-val groups_set_purpose: token -> group -> topic -> topic_result Lwt.t
+val groups_set_purpose: session -> group -> topic -> topic_result Lwt.t
 
 (** Sets the topic for a private group. *)
-val groups_set_topic: token -> group -> topic -> topic_result Lwt.t
+val groups_set_topic: session -> group -> topic -> topic_result Lwt.t
 
 (** Unarchives a private group. *)
-val groups_unarchive: token -> group -> [ `Success | parsed_auth_error | channel_error | `Not_archived | `User_is_restricted | bot_error ] Lwt.t
+val groups_unarchive: session -> group -> [ `Success | parsed_auth_error | channel_error | `Not_archived | `User_is_restricted | bot_error ] Lwt.t
 
 (** Close a direct message channel. *)
-val im_close: token -> conversation -> [ `Success of chat_close_obj | parsed_auth_error | channel_error | `User_does_not_own_channel ] Lwt.t
+val im_close: session -> conversation -> [ `Success of chat_close_obj | parsed_auth_error | channel_error | `User_does_not_own_channel ] Lwt.t
 
 (** Fetches history of messages and events from direct message channel. *)
-val im_history: token -> ?latest:timestamp -> ?oldest:timestamp -> ?count:int -> ?inclusive:bool -> conversation -> history_result Lwt.t
+val im_history: session -> ?latest:timestamp -> ?oldest:timestamp -> ?count:int -> ?inclusive:bool -> conversation -> history_result Lwt.t
 
 (** Lists direct message channels for the calling user. *)
-val im_list: token -> [ `Success of im_obj list | parsed_auth_error | bot_error ] Lwt.t
+val im_list: session -> [ `Success of im_obj list | parsed_auth_error | bot_error ] Lwt.t
 
 (** Sets the read cursor in a direct message channel. *)
-val im_mark: token -> conversation -> timestamp -> [ `Success | parsed_auth_error | channel_error | not_in_channel_error ] Lwt.t
+val im_mark: session -> conversation -> timestamp -> [ `Success | parsed_auth_error | channel_error | not_in_channel_error ] Lwt.t
 
 (** Opens a direct message channel. *)
-val im_open: token -> user -> [ `Success of im_open_obj | parsed_auth_error | user_error | user_visibility_error ] Lwt.t
+val im_open: session -> user -> [ `Success of im_open_obj | parsed_auth_error | user_error | user_visibility_error ] Lwt.t
 
-(** Exchanges a temporary OAuth code for an API token. *)
-val oauth_access: string -> string -> ?redirect_url:string -> string -> [ `Success of oauth_obj | `ParseFailure of string | oauth_error ] Lwt.t
+(** Exchanges a temporary OAuth code for an API session. *)
+val oauth_access: ?base_url:string -> string -> string -> ?redirect_url:string -> string -> [ `Success of oauth_obj | `ParseFailure of string | oauth_error ] Lwt.t
 
 (** Searches for messages and files matching a query. *)
-val search_all: token -> ?sort:sort_criterion -> ?sort_dir:sort_direction -> ?highlight:bool -> ?count:int -> ?page:int -> string -> [ `Success of search_obj | parsed_auth_error | bot_error ] Lwt.t
+val search_all: session -> ?sort:sort_criterion -> ?sort_dir:sort_direction -> ?highlight:bool -> ?count:int -> ?page:int -> string -> [ `Success of search_obj | parsed_auth_error | bot_error ] Lwt.t
 
 (** Searches for files matching a query. *)
-val search_files: token -> ?sort:sort_criterion -> ?sort_dir:sort_direction -> ?highlight:bool -> ?count:int -> ?page:int -> string -> [ `Success of search_obj | parsed_auth_error | bot_error ] Lwt.t
+val search_files: session -> ?sort:sort_criterion -> ?sort_dir:sort_direction -> ?highlight:bool -> ?count:int -> ?page:int -> string -> [ `Success of search_obj | parsed_auth_error | bot_error ] Lwt.t
 
 (** Searches for messages matching a query. *)
-val search_messages: token -> ?sort:sort_criterion -> ?sort_dir:sort_direction -> ?highlight:bool -> ?count:int -> ?page:int -> string -> [ `Success of search_obj | parsed_auth_error | bot_error ] Lwt.t
+val search_messages: session -> ?sort:sort_criterion -> ?sort_dir:sort_direction -> ?highlight:bool -> ?count:int -> ?page:int -> string -> [ `Success of search_obj | parsed_auth_error | bot_error ] Lwt.t
 
 (** Lists stars for a user. *)
-val stars_list: ?user:user -> ?count:int -> ?page:int -> token -> [ `Success of stars_list_obj | parsed_auth_error | user_error | bot_error ] Lwt.t
+val stars_list: ?user:user -> ?count:int -> ?page:int -> session -> [ `Success of stars_list_obj | parsed_auth_error | user_error | bot_error ] Lwt.t
 
 (** Gets the access logs for the current team. *)
-val team_access_logs: ?count:int -> ?page:int -> token -> [ `Success of team_access_log_obj | parsed_auth_error | `Paid_only | bot_error ] Lwt.t
+val team_access_logs: ?count:int -> ?page:int -> session -> [ `Success of team_access_log_obj | parsed_auth_error | `Paid_only | bot_error ] Lwt.t
 
 (** Gets information about the current team. *)
-val team_info: token -> [ `Success of team_obj | parsed_auth_error | bot_error ] Lwt.t
+val team_info: session -> [ `Success of team_obj | parsed_auth_error | bot_error ] Lwt.t
 
 (** Gets user presence information. *)
-val users_get_presence: token -> user -> [ `Success of presence | user_error | parsed_auth_error ] Lwt.t
+val users_get_presence: session -> user -> [ `Success of presence | user_error | parsed_auth_error ] Lwt.t
 
 (** Gets information about a user. *)
-val users_info: token -> user -> [ `Success of user_obj | parsed_auth_error | user_error | user_visibility_error ] Lwt.t
+val users_info: session -> user -> [ `Success of user_obj | parsed_auth_error | user_error | user_visibility_error ] Lwt.t
 
 (** Lists all users in a Slack team. *)
-val users_list: token -> [ `Success of user_obj list | parsed_auth_error ] Lwt.t
+val users_list: session -> [ `Success of user_obj list | parsed_auth_error ] Lwt.t
 
 (** Marks a user as active. *)
-val users_set_active: token -> [ `Success | parsed_auth_error | bot_error ] Lwt.t
+val users_set_active: session -> [ `Success | parsed_auth_error | bot_error ] Lwt.t
 
 (** Manually sets user presence. *)
-val users_set_presence: token -> presence -> [ `Success | parsed_auth_error | presence_error ] Lwt.t
+val users_set_presence: session -> presence -> [ `Success | parsed_auth_error | presence_error ] Lwt.t


### PR DESCRIPTION
This changes the signature of all functions that take a `token` and has them take a `session` instead. Like `token`, `session` is an abstract type.

For backwards compatibility, `token_of_string` now returns a session instead. In order to (optionally) provide a different `base_url`, you need to use the new `make_session` function instead.

The two API functions that didn't take a `token` (`api_test` and `oauth_access`) now accept an optional `?base_url` parameter and are otherwise unchanged.

The `slack_notify` command line tool now accepts a `--base-url` option (which does the obvious thing), mostly to demonstrate usage.