### PR TITLE
Fix files_list

### DIFF
--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -317,9 +317,6 @@ type file_obj = {
 
   size: int;
 
-  (* These two are deprecated and appear to be gone. *)
-  (* url: string; *)
-  (* url_download: string; *)
   url_private: string;
   url_private_download: string;
 

--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -317,31 +317,32 @@ type file_obj = {
 
   size: int;
 
-  url: string;
-  url_download: string;
+  (* These two are deprecated and appear to be gone. *)
+  (* url: string; *)
+  (* url_download: string; *)
   url_private: string;
   url_private_download: string;
 
-  thumb_64: string;
-  thunb_80: string;
-  thumb_360: string;
-  thumb_360_gif: string;
-  thumb_360_w: int;
-  thumb_360_h: int;
+  thumb_64: string option [@default None];
+  thunb_80: string option [@default None];
+  thumb_360: string option [@default None];
+  thumb_360_gif: string option [@default None];
+  thumb_360_w: int option [@default None];
+  thumb_360_h: int option [@default None];
 
   permalink: string;
-  edit_link: string;
-  preview: string;
-  preview_highlight: string;
-  lines: int;
-  lines_more: int;
+  edit_link: string option [@default None];
+  preview: string option [@default None];
+  preview_highlight: string option [@default None];
+  lines: int option [@default None];
+  lines_more: int option [@default None];
 
   is_public: bool;
   (*public_url_shared: ???;*)
   channels: channel list;
   groups: group list;
   ims: conversation list;
-  initial_comment: Yojson.Safe.json;
+  initial_comment: Yojson.Safe.json option [@default None];
   num_stars: int option [@default None];
 } [@@deriving of_yojson { strict = false }]
 

--- a/src/slacko.mli
+++ b/src/slacko.mli
@@ -529,9 +529,6 @@ type file_obj = {
 
   size: int;
 
-  (* These two are deprecated and appear to be gone. *)
-  (* url: string; *)
-  (* url_download: string; *)
   url_private: string;
   url_private_download: string;
 

--- a/src/slacko.mli
+++ b/src/slacko.mli
@@ -529,31 +529,32 @@ type file_obj = {
 
   size: int;
 
-  url: string;
-  url_download: string;
+  (* These two are deprecated and appear to be gone. *)
+  (* url: string; *)
+  (* url_download: string; *)
   url_private: string;
   url_private_download: string;
 
-  thumb_64: string;
-  thunb_80: string;
-  thumb_360: string;
-  thumb_360_gif: string;
-  thumb_360_w: int;
-  thumb_360_h: int;
+  thumb_64: string option;
+  thunb_80: string option;
+  thumb_360: string option;
+  thumb_360_gif: string option;
+  thumb_360_w: int option;
+  thumb_360_h: int option;
 
   permalink: string;
-  edit_link: string;
-  preview: string;
-  preview_highlight: string;
-  lines: int;
-  lines_more: int;
+  edit_link: string option;
+  preview: string option;
+  preview_highlight: string option;
+  lines: int option;
+  lines_more: int option;
 
   is_public: bool;
   (*public_url_shared: ???;*)
   channels: channel list;
   groups: group list;
   ims: conversation list;
-  initial_comment: Yojson.Safe.json;
+  initial_comment: Yojson.Safe.json option;
   num_stars: int option;
 }
 


### PR DESCRIPTION
This addresses one of the items in #10.

I've tested this using my code from #14 in a mostly unused slack team that only has default files. I think I've made all the necessary fields optional, but it's hard to tell for sure.

Idea for later: Maybe for some object types we should limit the records to the core fields that everything has and then also return all the other fields along with some tools for getting their values? That way the caller gets the information they probably care about in a nice format, but can still get at the obscure (and sometimes undocumented) fields that only some instances have without needing to update slacko every time slack adds a new one.