### PR TITLE
Fix *_history calls

### DIFF
--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -417,7 +417,7 @@ type message_obj = {
 } [@@deriving of_yojson { strict = false }]
 
 type history_obj = {
-  latest: timestamp;
+  latest: timestamp option [@default None];
   messages: message_obj list;
   has_more: bool;
 } [@@deriving of_yojson { strict = false }]

--- a/src/slacko.mli
+++ b/src/slacko.mli
@@ -402,7 +402,7 @@ type message_obj = {
 
 (* The message history of a channel or group conversation. *)
 type history_obj = {
-  latest: timestamp;
+  latest: timestamp option;
   messages: message_obj list;
   has_more: bool;
 }


### PR DESCRIPTION
This addresses three of the items in #10.

#14 tests all three `*_history` functions and this change fixes all of them.