### PR TITLE
Stop masking errors in channel lookups

### DIFF
--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -781,8 +781,10 @@ let id_of_channel session = function
   | ChannelName name ->
     let base = String.sub name 1 @@ String.length name - 1 in
     lookupk session channels_list (fun (x:channel_obj) -> x.name = base) @@ function
+    | [] -> `Channel_not_found
     | [{id = ChannelId s; _}] -> `Found s
-    | _ -> `Channel_not_found
+    | [_] -> failwith "Bad result from channel id lookup."
+    | _::_::_ -> failwith "Too many results from channel id lookup."
 
 (* like id_of_channel but does not resolve names to ids *)
 let string_of_channel = function
@@ -793,15 +795,19 @@ let id_of_user session = function
   | UserId id -> Lwt.return @@ `Found id
   | UserName name ->
     lookupk session users_list (fun (x:user_obj) -> x.name = name) @@ function
+    | [] -> `User_not_found
     | [{id = UserId s; _}] -> `Found s
-    | _ -> `User_not_found
+    | [_] -> failwith "Bad result from user id lookup."
+    | _::_::_ -> failwith "Too many results from user id lookup."
 
 let id_of_group session = function
   | GroupId id -> Lwt.return @@ `Found id
   | GroupName name ->
     lookupk session groups_list (fun (x:group_obj) -> x.name = name) @@ function
+    | [] -> `Channel_not_found
     | [{id = GroupId s; _}] -> `Found s
-    | _ -> `Channel_not_found
+    | [_] -> failwith "Bad result from group id lookup."
+    | _::_::_ -> failwith "Too many results from group id lookup."
 
 let id_of_chat session = function
   | Channel c -> id_of_channel session c

--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -765,7 +765,6 @@ let groups_list ?exclude_archived session =
       (match d |> groups_list_obj_of_yojson with
         | Result.Ok x -> `Success x.groups
         | Result.Error x -> `ParseFailure x)
-    | #bot_error
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
@@ -1508,7 +1507,6 @@ let im_list session =
       (match d |> im_list_obj_of_yojson with
         | Result.Ok x -> `Success x.ims
         | Result.Error x -> `ParseFailure x)
-    | #bot_error
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 

--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -768,8 +768,10 @@ let groups_list ?exclude_archived session =
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
+type 'a listfn = session -> [`Success of 'a list | parsed_auth_error] Lwt.t
+
 (* look up the id of query from results provided by the listfn *)
-let lookupk session listfn filterfn k =
+let lookupk session (listfn : 'a listfn) filterfn k =
   match%lwt listfn session with
   | #parsed_auth_error as e -> Lwt.return e
   | `Success items -> Lwt.return @@ k @@ List.filter filterfn items

--- a/src/slacko.ml
+++ b/src/slacko.ml
@@ -768,29 +768,19 @@ let groups_list ?exclude_archived session =
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
-exception No_matches
-exception No_unique_matches
-exception Lookup_failed
-
 (* look up the id of query from results provided by the listfn *)
 let lookupk session listfn filterfn k =
   match%lwt listfn session with
-  | `Success channels -> (match List.filter filterfn channels with
-    | [] -> Lwt.fail No_matches
-    | [x] -> Lwt.return @@ k x
-    | _ -> Lwt.fail No_unique_matches)
-  | _ -> Lwt.fail Lookup_failed
+  | #parsed_auth_error as e -> Lwt.return e
+  | `Success items -> Lwt.return @@ k @@ List.filter filterfn items
 
-let id_of_channel session : _ -> [ `User_not_found | `Channel_not_found | `Found of string ] Lwt.t = function
+let id_of_channel session = function
   | ChannelId id -> Lwt.return @@ `Found id
   | ChannelName name ->
     let base = String.sub name 1 @@ String.length name - 1 in
-    match%lwt (lookupk session channels_list (fun (x:channel_obj) -> x.name = base) @@ function
-    | {id = ChannelId s; _} -> Some s
-    | {id = ChannelName _; _} -> None) with
-    | exception _ -> Lwt.return `Channel_not_found
-    | Some v -> Lwt.return @@ `Found v
-    | None -> Lwt.return `Channel_not_found
+    lookupk session channels_list (fun (x:channel_obj) -> x.name = base) @@ function
+    | [{id = ChannelId s; _}] -> `Found s
+    | _ -> `Channel_not_found
 
 (* like id_of_channel but does not resolve names to ids *)
 let string_of_channel = function
@@ -800,24 +790,18 @@ let string_of_channel = function
 let id_of_user session = function
   | UserId id -> Lwt.return @@ `Found id
   | UserName name ->
-    match%lwt (lookupk session users_list (fun (x:user_obj) -> x.name = name) @@ function
-    | {id = UserId s; _} -> Some s
-    | {id = UserName _; _} -> None) with
-    | exception _ -> Lwt.return `User_not_found
-    | Some v -> Lwt.return @@ `Found v
-    | None -> Lwt.return `User_not_found
+    lookupk session users_list (fun (x:user_obj) -> x.name = name) @@ function
+    | [{id = UserId s; _}] -> `Found s
+    | _ -> `User_not_found
 
 let id_of_group session = function
   | GroupId id -> Lwt.return @@ `Found id
   | GroupName name ->
-    match%lwt (lookupk session groups_list (fun (x:group_obj) -> x.name = name) @@ function
-    | {id = GroupId s; _} -> Some s
-    | {id = GroupName _; _} -> None) with
-    | exception _ -> Lwt.return `Channel_not_found
-    | Some v -> Lwt.return @@ `Found v
-    | None -> Lwt.return `Channel_not_found
+    lookupk session groups_list (fun (x:group_obj) -> x.name = name) @@ function
+    | [{id = GroupId s; _}] -> `Found s
+    | _ -> `Channel_not_found
 
-let id_of_chat session : _ -> [ `Found of string | `Channel_not_found | `User_not_found ] Lwt.t = function
+let id_of_chat session = function
   | Channel c -> id_of_channel session c
   | Im i -> Lwt.return @@ `Found i
   | User u -> id_of_user session u
@@ -919,7 +903,8 @@ let auth_test session =
 (* Operator for unwrapping channel_ids *)
 let (|->) m f =
   match%lwt m with
-  | `Channel_not_found -> Lwt.return `Channel_not_found
+  | `Channel_not_found
+  | #parsed_auth_error as e -> Lwt.return e
   | `User_not_found -> Lwt.return `Unknown_error
   | `Found v -> f v
 
@@ -927,7 +912,8 @@ let (|->) m f =
 let (|+>) m f =
   match%lwt m with
   | `Channel_not_found -> Lwt.return `Unknown_error
-  | `User_not_found -> Lwt.return `User_not_found
+  | `User_not_found
+  | #parsed_auth_error as e -> Lwt.return e
   | `Found v -> f v
 
 let channels_archive session channel =

--- a/src/slacko.mli
+++ b/src/slacko.mli
@@ -797,7 +797,7 @@ val groups_kick: session -> group -> user -> [ `Success | parsed_auth_error | ch
 val groups_leave: session -> group -> [ `Success | parsed_auth_error | channel_error | archive_error | leave_last_channel_error | last_member_error | `User_is_ultra_restricted | bot_error ] Lwt.t
 
 (** Lists private groups that the calling user has access to. *)
-val groups_list: ?exclude_archived:bool -> session -> [ `Success of group_obj list | parsed_auth_error | bot_error ] Lwt.t
+val groups_list: ?exclude_archived:bool -> session -> [ `Success of group_obj list | parsed_auth_error ] Lwt.t
 
 (** Sets the read cursor in a private group. *)
 val groups_mark: session -> group -> timestamp -> [ `Success | parsed_auth_error | channel_error | archive_error | not_in_channel_error ] Lwt.t
@@ -824,7 +824,7 @@ val im_close: session -> conversation -> [ `Success of chat_close_obj | parsed_a
 val im_history: session -> ?latest:timestamp -> ?oldest:timestamp -> ?count:int -> ?inclusive:bool -> conversation -> history_result Lwt.t
 
 (** Lists direct message channels for the calling user. *)
-val im_list: session -> [ `Success of im_obj list | parsed_auth_error | bot_error ] Lwt.t
+val im_list: session -> [ `Success of im_obj list | parsed_auth_error ] Lwt.t
 
 (** Sets the read cursor in a direct message channel. *)
 val im_mark: session -> conversation -> timestamp -> [ `Success | parsed_auth_error | channel_error | not_in_channel_error ] Lwt.t


### PR DESCRIPTION
Currently, any API call that requires a channel (or a group or a user) starts by making a lookup call. In this call, any failure response is silently replaced with `channel_not_found` (or `user_not_found`) which leads to much confusion when trying to figure out why something isn't working.

For `lookupk` to pass through all the errors it gets without running into type trouble, all the list functions it's passed must have the same set of errors in their return types. I checked slack's API documentation to see if `groups_list` actual needs the `bot_error` in its signature. Both https://api.slack.com/methods/groups.list and https://api.slack.com/bot-users indicate that it doesn't, so I removed it. (I did the same for `im_list` even it isn't used with `lookupk`, because it probably should be at some point.)

There's probably some more cleanup that could be done here, but I didn't want to change too much before getting a review. :-)