### PR TITLE
Add public_name to slacko library and don't wrap it.

### DIFF
--- a/src/lib/jbuild
+++ b/src/lib/jbuild
@@ -2,5 +2,7 @@
 
 (library
   ((name slacko)
+   (public_name slacko)
+   (wrapped false)
    (libraries (lwt cohttp-lwt-unix yojson ppx_deriving_yojson.runtime))
    (preprocess (pps (lwt_ppx ppx_deriving_yojson)))))


### PR DESCRIPTION
The current master does not provide the library as a public API (e.g. if pinning its `--dev-repo`).
