### PR TITLE
Use us precision to represent timestamps.

### DIFF
--- a/src/lib/slacko.ml
+++ b/src/lib/slacko.ml
@@ -704,9 +704,8 @@ let query =
 let query_post body =
   process << Cohttp_unix.Client.post ~body
 
-(* like string_of_float, but doesn't truncate numbers to end with '.',
- * e.g. '42.' *)
-let string_of_timestamp = Printf.sprintf "%.f"
+(* like string_of_float, but with 6 digits precision as used by Slack. *)
+let string_of_timestamp = Printf.sprintf "%.6f"
 
 let identity x = x
 


### PR DESCRIPTION
Using `%.f` means whole seconds only which makes history searches imprecise.  This uses 6 digits to match what Slack supports.

Counting digits, it seems a `float` should suffice to provide the given precision, though I still worry about rounding errors converting between base 2 and base 10.  Would it be better to use precise time stamps, e.g. using `Ptime.t`?  I know at least two indicators that Slack deals with microsecond-precise timestamps:

* The channel history method has an `inclusive` option, which makes no sense if timestamps have rounding errors.
* When one receives edit and delete events though the RTM, they suggest matching past messages using channel and time stamp only.  That is, the time stamp identifies a message in a channel, so they probably ensure that there is at least one microsecond between messages.

I can send a new PR changing time stamps to `Ptime.t` if you wish.