### PR TITLE
Update chat post/update to latest Slack API

### DIFF
--- a/src/lib/slacko.ml
+++ b/src/lib/slacko.ml
@@ -1134,6 +1134,8 @@ let jsonify_attachments attachments =
   |> Yojson.Safe.to_string
 
 let chat_post_message session chat
+  ?as_user ?link_names ?mrkdwn
+  ?reply_broadcast ?thread_ts ?unfurl_links ?unfurl_media
   ?username ?parse ?icon_url ?icon_emoji ?(attachments=[]) text =
   id_of_chat session chat |-> fun chat_id ->
   endpoint "chat.postMessage" session
@@ -1144,6 +1146,13 @@ let chat_post_message session chat
     |> optionally_add "icon_url" icon_url
     |> optionally_add "icon_emoji" icon_emoji
     |> definitely_add "attachments" @@ jsonify_attachments attachments
+    |> optionally_add "as_user" @@ maybe string_of_bool as_user
+    |> optionally_add "link_names" @@ maybe string_of_bool link_names
+    |> optionally_add "mrkdwn" @@ maybe string_of_bool mrkdwn
+    |> optionally_add "reply_broadcast" @@ maybe string_of_bool reply_broadcast
+    |> optionally_add "thread_ts" @@ maybe string_of_timestamp thread_ts
+    |> optionally_add "unfurl_links" @@ maybe string_of_bool unfurl_links
+    |> optionally_add "unfurl_media" @@ maybe string_of_bool unfurl_media
     |> query
     >|= function
     | `Json_response d ->
@@ -1157,12 +1166,16 @@ let chat_post_message session chat
     | #rate_error as res -> res
     | _ -> `Unknown_error
 
-let chat_update session ts chat text =
+let chat_update session ts chat ?as_user ?attachments ?link_names ?parse text =
   id_of_chat session chat |-> fun chat_id ->
   endpoint "chat.update" session
     |> definitely_add "channel" chat_id
     |> definitely_add "ts" @@ string_of_timestamp ts
     |> definitely_add "text" text
+    |> optionally_add "as_user" @@ maybe string_of_bool as_user
+    |> optionally_add "attachments" @@ maybe jsonify_attachments attachments
+    |> optionally_add "link_names" @@ maybe string_of_bool link_names
+    |> optionally_add "parse" parse
     |> query
     >|= function
     | `Json_response d ->

--- a/src/lib/slacko.ml
+++ b/src/lib/slacko.ml
@@ -196,6 +196,8 @@ type conversation = string
 
 type user = UserId of string | UserName of string
 
+type bot = BotId of string
+
 type group = GroupId of string | GroupName of string
 
 (* TODO: Sure about user? *)
@@ -219,6 +221,14 @@ let timestamp_of_yojson = function
 let user_of_yojson = function
   | `String x -> Result.Ok (UserId x)
   | _ -> Result.Error "Couldn't parse user type"
+
+let bot_of_string s =
+  if s.[0] = 'B' then BotId s else invalid_arg ("bot_of_string " ^ s)
+
+let bot_of_yojson = function
+  | `String x -> Result.Ok (bot_of_string x)
+  | _ -> Result.Error "Couldn't parse bot type"
+
 
 let channel_of_yojson = function
   | `String x -> Result.Ok (ChannelId x)
@@ -406,6 +416,7 @@ type message_obj = {
   type': string [@key "type"];
   ts: timestamp;
   user: user option [@default None];
+  bot_id: bot option [@default None];
   text: string option;
   is_starred: bool option [@default None];
 } [@@deriving of_yojson { strict = false }]

--- a/src/lib/slacko.mli
+++ b/src/lib/slacko.mli
@@ -284,6 +284,9 @@ type conversation
 (** An user, represented by either a user name or a user id. *)
 type user
 
+(** A bot user, represented by a bot id *)
+type bot
+
 (** A group, a private subset of users chatting together. *)
 type group
 
@@ -396,6 +399,7 @@ type message_obj = {
   type': string;
   ts: timestamp;
   user: user option;
+  bot_id: bot option;
   text: string option;
   is_starred: bool option;
 }
@@ -675,6 +679,8 @@ val group_of_string: string -> group
     simple user name in which case every API call will look up the user name
     to an id in an additional request. *)
 val user_of_string: string -> user
+
+val bot_of_string : string -> bot
 
 (** Constructs a channel out of a given string. Can either be a channel id
     starting with a capital 'C' which is the preferred way or a channel name

--- a/src/lib/slacko.mli
+++ b/src/lib/slacko.mli
@@ -751,10 +751,10 @@ val channels_unarchive: session -> channel -> [ `Success | parsed_auth_error | c
 val chat_delete: session -> timestamp -> chat -> [ `Success of chat_obj | parsed_auth_error | channel_error | message_error ] Lwt.t
 
 (** Sends a message to a channel. *)
-val chat_post_message: session -> chat -> ?username:string -> ?parse:string -> ?icon_url:string -> ?icon_emoji:string -> ?attachments:attachment_obj list -> message -> [ `Success of chat_obj | parsed_auth_error | channel_error | archive_error | message_length_error | attachments_error | rate_error | bot_error ] Lwt.t
+val chat_post_message: session -> chat -> ?as_user:bool -> ?link_names:bool -> ?mrkdwn:bool -> ?reply_broadcast:bool -> ?thread_ts:timestamp -> ?unfurl_links:bool -> ?unfurl_media:bool -> ?username:string -> ?parse:string -> ?icon_url:string -> ?icon_emoji:string -> ?attachments:attachment_obj list -> message -> [ `Success of chat_obj | parsed_auth_error | channel_error | archive_error | message_length_error | attachments_error | rate_error | bot_error ] Lwt.t
 
 (** Updates a message. *)
-val chat_update: session -> timestamp -> chat -> message -> [ `Success of chat_obj | parsed_auth_error | channel_error | message_update_error | message_length_error | attachments_error ] Lwt.t
+val chat_update: session -> timestamp -> chat -> ?as_user:bool -> ?attachments:attachment_obj list -> ?link_names:bool -> ?parse:string -> message -> [ `Success of chat_obj | parsed_auth_error | channel_error | message_update_error | message_length_error | attachments_error ] Lwt.t
 
 (** Lists custom emoji for a team. *)
 val emoji_list: session -> [ `Success of emoji list | parsed_auth_error ] Lwt.t


### PR DESCRIPTION
I've been hacking on a small chat bot, the version of slacko in OPAM failed  to parse channel history, but luckily the git branch of slacko did (due to message_obj having strict=false). The message object has got quite a few optional fields that can show up (e.g. if you are writing a bot and posting messages as a bot).

Message attachments are also very neat, and I missed them from the chat update API, so I've updated both 'chat post' and 'chat update' according to latest Slack APIs.

One caveat: had to use channel IDs, lookup by channel name was way too slow with thousands of channels, and also at some point Slack decided to paginate the replies meaning that `slacko` was suddenly unable to lookup the channel name anymore. The channel ID can be found by double clicking on the channel in the slack webapp and looking in the titlebar, wish they had a more efficient lookup API than listing everything :(