### PR TITLE
Handle optional fields in user_obj

### DIFF
--- a/src/lib/slacko.ml
+++ b/src/lib/slacko.ml
@@ -262,17 +262,17 @@ type user_obj = {
   id: user;
   name: string;
   deleted: bool;
-  color: string;
-  real_name: string;
+  color: string option [@default None];
+  real_name: string option [@default None];
   tz: string option [@default None];
-  tz_label: string;
-  tz_offset: int;
+  tz_label: string option [@default None];
+  tz_offset: int [@default 0];
   profile: Yojson.Safe.json;
-  is_admin: bool;
-  is_owner: bool;
-  is_primary_owner: bool;
-  is_restricted: bool;
-  is_ultra_restricted: bool;
+  is_admin: bool [@default false];
+  is_owner: bool [@default false];
+  is_primary_owner: bool [@default false];
+  is_restricted: bool [@default false];
+  is_ultra_restricted: bool [@default false];
   is_bot: bool;
   has_files: bool [@default false];
 } [@@deriving of_yojson { strict = false } ]

--- a/src/lib/slacko.mli
+++ b/src/lib/slacko.mli
@@ -315,10 +315,10 @@ type user_obj = {
   id: user;
   name: string;
   deleted: bool;
-  color: string;
-  real_name: string;
+  color: string option;
+  real_name: string option;
   tz: string option;
-  tz_label: string;
+  tz_label: string option;
   tz_offset: int;
   profile: Yojson.Safe.json;
   is_admin: bool;

--- a/test/abbrtypes.ml
+++ b/test/abbrtypes.ml
@@ -109,17 +109,17 @@ type abbr_user_obj = {
   (* id: user; *)
   name: string;
   deleted: bool;
-  color: string;
-  real_name: string;
+  color: string option [@default None];
+  real_name: string option [@default None];
   tz: string option [@default None];
-  tz_label: string;
-  tz_offset: int;
+  tz_label: string option [@default None];
+  tz_offset: int [@default 0];
   profile: json;
-  is_admin: bool;
-  is_owner: bool;
-  is_primary_owner: bool;
-  is_restricted: bool;
-  is_ultra_restricted: bool;
+  is_admin: bool [@default false];
+  is_owner: bool [@default false];
+  is_primary_owner: bool [@default false];
+  is_restricted: bool [@default false];
+  is_ultra_restricted: bool [@default false];
   is_bot: bool;
   has_files: bool [@default false];
 } [@@deriving show, yojson { strict = false } ]


### PR DESCRIPTION
When a user is deleted, most of the fields of user_obj are optional. I used default values most of the time because I think they make sense and reduce the breakage of the interface. But I can make all the fields optional if you prefer.