### PR TITLE
Do less brittle trickery when building

### DIFF
--- a/src/lib/timestamp.ml
+++ b/src/lib/timestamp.ml
@@ -26,6 +26,7 @@ let int64_pow b n =
   loop b n 1L
 
 type t = Ptime.t
+let pp = Ptime.pp_human ~frac_s:6 ()
 
 let of_string x =
   let d_ps_of_intlit intlit =

--- a/src/lib/timestamp.mli
+++ b/src/lib/timestamp.mli
@@ -25,3 +25,5 @@ val to_string : t -> string
 val of_yojson : Yojson.Safe.json -> (t, string) result
 
 val to_yojson : t -> Yojson.Safe.json
+
+val pp : Format.formatter -> t -> unit

--- a/test/abbrtypes.ml
+++ b/test/abbrtypes.ml
@@ -3,12 +3,6 @@
    those values at all. Therefore, we copy the record type that use these and
    skip the problematic fields. *)
 
-module Timestamp = struct
-  include Slacko__Timestamp
-
-  let pp = Ptime.pp_human ~frac_s:6 ()
-end
-
 (* Wrap Yojson.Safe.json so we don't have to keep providing printers for it. *)
 type json = Yojson.Safe.json
 [@@deriving yojson]

--- a/test/dune
+++ b/test/dune
@@ -1,8 +1,13 @@
+(rule
+  (targets timestamp.ml)
+  (deps ../src/lib/timestamp.ml)
+  (action (copy %{deps} %{targets})))
+
 (executable
   (name test_slacko)
   (libraries slacko oUnit)
   ;; disable warning 39, unused rec flag, because ppx_deriving_yojson generates these
-  (flags (:standard -w -39 -I src/lib/.slacko.objs/.private))
+  (flags (:standard -w -39))
   (preprocess (pps ppx_deriving_yojson ppx_deriving.std)))
 
 (alias


### PR DESCRIPTION
It seems `dune` has changed some internals and now the trickery used in building tests fails. This converts it to do slightly less trickery.