### PR TITLE
Remove deprecation warnings for recent versions of yojson

### DIFF
--- a/slacko.opam
+++ b/slacko.opam
@@ -9,7 +9,7 @@ run-test: [make "test"]
 depends: [
   "dune" {build & >= "1.2.0"}
   "cmdliner"
-  "yojson"
+  "yojson" {>= "1.6.0"}
   "lwt" {>= "3.2.0"}
   "lwt_ppx"
   "tls" | "ssl"

--- a/src/lib/slacko.ml
+++ b/src/lib/slacko.ml
@@ -252,7 +252,7 @@ type channel_obj = {
   topic: topic_obj;
   purpose: topic_obj;
   last_read: Timestamp.t option [@default None];
-  latest: Yojson.Safe.json option [@default None];
+  latest: Yojson.Safe.t option [@default None];
   unread_count: int option [@default None];
   unread_count_display: int option [@default None];
   num_members: int option [@default None];
@@ -267,7 +267,7 @@ type user_obj = {
   tz: string option [@default None];
   tz_label: string option [@default None];
   tz_offset: int [@default 0];
-  profile: Yojson.Safe.json;
+  profile: Yojson.Safe.t;
   is_admin: bool [@default false];
   is_owner: bool [@default false];
   is_primary_owner: bool [@default false];
@@ -291,7 +291,7 @@ type group_obj = {
   last_read: Timestamp.t option [@default None];
   unread_count: int option [@default None];
   unread_count_display: int option [@default None];
-  latest: Yojson.Safe.json option [@default None];
+  latest: Yojson.Safe.t option [@default None];
 } [@@deriving of_yojson { strict = false }]
 
 type file_obj = {
@@ -336,7 +336,7 @@ type file_obj = {
   channels: channel list;
   groups: group list;
   ims: conversation list;
-  initial_comment: Yojson.Safe.json option [@default None];
+  initial_comment: Yojson.Safe.t option [@default None];
   num_stars: int option [@default None];
 } [@@deriving of_yojson { strict = false }]
 
@@ -530,7 +530,7 @@ type files_list_obj = {
 
 type stars_list_obj = {
   (* TODO proper types *)
-  items: Yojson.Safe.json list;
+  items: Yojson.Safe.t list;
   paging: paging_obj;
 } [@@deriving of_yojson { strict = false }]
 
@@ -558,7 +558,7 @@ type team_obj = {
   name: string;
   domain: string;
   email_domain: string;
-  icon: Yojson.Safe.json;
+  icon: Yojson.Safe.t;
 } [@@deriving of_yojson { strict = false }]
 
 type login_obj = {

--- a/src/lib/slacko.mli
+++ b/src/lib/slacko.mli
@@ -320,7 +320,7 @@ type user_obj = {
   tz: string option;
   tz_label: string option;
   tz_offset: int;
-  profile: Yojson.Safe.json;
+  profile: Yojson.Safe.t;
   is_admin: bool;
   is_owner: bool;
   is_primary_owner: bool;
@@ -345,7 +345,7 @@ type group_obj = {
   last_read: timestamp option;
   unread_count: int option;
   unread_count_display: int option;
-  latest: Yojson.Safe.json option;
+  latest: Yojson.Safe.t option;
 }
 
 (** Object representing information about a Slack channel. *)
@@ -362,7 +362,7 @@ type channel_obj = {
   topic: topic_obj;
   purpose: topic_obj;
   last_read: timestamp option;
-  latest: Yojson.Safe.json option;
+  latest: Yojson.Safe.t option;
   unread_count: int option;
   unread_count_display: int option;
   num_members: int option;
@@ -556,7 +556,7 @@ type file_obj = {
   channels: channel list;
   groups: group list;
   ims: conversation list;
-  initial_comment: Yojson.Safe.json option;
+  initial_comment: Yojson.Safe.t option;
   num_stars: int option;
 }
 
@@ -575,7 +575,7 @@ type files_list_obj = {
 
 (** Information about starred items. *)
 type stars_list_obj = {
-  items: Yojson.Safe.json list;
+  items: Yojson.Safe.t list;
   paging: paging_obj;
 }
 
@@ -602,7 +602,7 @@ type team_obj = {
   name: string;
   domain: string;
   email_domain: string;
-  icon: Yojson.Safe.json;
+  icon: Yojson.Safe.t;
 }
 
 type login_obj = {
@@ -700,7 +700,7 @@ val conversation_of_string: string -> conversation
     @param base_url If set, overrides the Slack API base URL.
     @param foo A dummy value that will be returned by the API.
     @param error If set, will return a specific kind of error. *)
-val api_test: ?base_url:string -> ?foo:string -> ?error:string -> unit -> [ `Success of Yojson.Safe.json | api_error ] Lwt.t
+val api_test: ?base_url:string -> ?foo:string -> ?error:string -> unit -> [ `Success of Yojson.Safe.t | api_error ] Lwt.t
 
 (** Checks authentication & identity.
     @param session The session containing the authentication token. *)

--- a/src/lib/timestamp.mli
+++ b/src/lib/timestamp.mli
@@ -22,8 +22,8 @@ type t = Ptime.t
 
 val to_string : t -> string
 
-val of_yojson : Yojson.Safe.json -> (t, string) result
+val of_yojson : Yojson.Safe.t -> (t, string) result
 
-val to_yojson : t -> Yojson.Safe.json
+val to_yojson : t -> Yojson.Safe.t
 
 val pp : Format.formatter -> t -> unit

--- a/test/abbrtypes.ml
+++ b/test/abbrtypes.ml
@@ -3,8 +3,8 @@
    those values at all. Therefore, we copy the record type that use these and
    skip the problematic fields. *)
 
-(* Wrap Yojson.Safe.json so we don't have to keep providing printers for it. *)
-type json = Yojson.Safe.json
+(* Wrap Yojson.Safe.t so we don't have to keep providing printers for it. *)
+type json = Yojson.Safe.t
 [@@deriving yojson]
 let pp_json fmt json = Format.pp_print_string fmt (Yojson.Safe.to_string json)
 


### PR DESCRIPTION
Ran into this when trying to add some new features for a recent version of Slack. Using `Yojson.Safe.json` is depreciated as of https://github.com/ocaml-community/yojson/releases/tag/1.6.0