### PR TITLE
fix: update Cmdliner usage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,15 +15,14 @@ jobs:
           - ubuntu-20.04
 
         ocaml-compiler:
-          - 4.04.x
-          - 4.07.x
-          - 4.13.x
+          - 4.08.x
+          - 4.14.x
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2

--- a/slacko.opam
+++ b/slacko.opam
@@ -7,8 +7,9 @@ doc: "https://leonidas-from-xiv.github.io/slacko/"
 build: [["dune" "build" "-p" name "-j" jobs]]
 run-test: [make "test"]
 depends: [
+  "ocaml" {>= "4.08"}
   "dune" {build & >= "1.2.0"}
-  "cmdliner"
+  "cmdliner" {>= "1.1.0"}
   "yojson" {>= "1.6.0"}
   "lwt" {>= "3.2.0"}
   "lwt_ppx"

--- a/src/cli/slack_notify.ml
+++ b/src/cli/slack_notify.ml
@@ -52,7 +52,7 @@ let attachment =
 
 let info =
   let doc = "Posts messages to Slack" in
-  Cmdliner.Term.info "slack-notify" ~doc
+  Cmdliner.Cmd.info "slack-notify" ~doc
 
 let execute base_url token username channel icon_url icon_emoji attachment_text msg =
   "Your token is " ^ token ^ ", the channel is " ^ channel
@@ -90,10 +90,9 @@ let execute base_url token username channel icon_url icon_emoji attachment_text 
   |> Lwt_main.run
 
 let execute_t = Cmdliner.Term.(
-    pure execute $ base_url $ token $ username $ channel $ icon_url $ icon_emoji
+    const execute $ base_url $ token $ username $ channel $ icon_url $ icon_emoji
     $ attachment $ message)
 
 let () =
-  match Cmdliner.Term.eval (execute_t, info) with
-    | `Error _ -> exit 1
-    | _ -> exit 0
+  let cmd = Cmdliner.Cmd.v info execute_t in
+  exit Cmdliner.(Cmd.eval cmd)


### PR DESCRIPTION
Fix the following compilation errors:

```
 $ dune build
File "src/cli/slack_notify.ml", line 55, characters 2-20:
55 |   Cmdliner.Term.info "slack-notify" ~doc
       ^^^^^^^^^^^^^^^^^^
Error (alert deprecated): Cmdliner.Term.info
Use Cmd.info instead.
File "src/cli/slack_notify.ml", line 93, characters 4-8:
93 |     pure execute $ base_url $ token $ username $ channel $ icon_url $ icon_emoji
         ^^^^
Error (alert deprecated): Cmdliner.Term.pure
Use Term.const instead.
File "src/cli/slack_notify.ml", line 97, characters 8-26:
97 |   match Cmdliner.Term.eval (execute_t, info) with
             ^^^^^^^^^^^^^^^^^^
Error (alert deprecated): Cmdliner.Term.eval
Use Cmd.v and one of Cmd.eval* instead.
```