### PR TITLE
Remove `result` dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,6 @@ those, upload and search files, manage presence.")
     (cohttp-lwt-unix (>= 1.0.0))
     (ppx_deriving_yojson (>= 3.3))
     ptime
-    result
     (ounit2 (and :with-test (>= 2.2)))
     (ppx_deriving (and :with-test (>= 5.2.1))))
   (conflicts

--- a/slacko.opam
+++ b/slacko.opam
@@ -21,7 +21,6 @@ depends: [
   "cohttp-lwt-unix" {>= "1.0.0"}
   "ppx_deriving_yojson" {>= "3.3"}
   "ptime"
-  "result"
   "ounit2" {with-test & >= "2.2"}
   "ppx_deriving" {with-test & >= "5.2.1"}
 ]

--- a/src/lib/slacko.ml
+++ b/src/lib/slacko.ml
@@ -210,28 +210,28 @@ type sort_direction = Ascending | Descending
 type presence = Auto | Away
 
 let user_of_yojson = function
-  | `String x -> Result.Ok (UserId x)
-  | _ -> Result.Error "Couldn't parse user type"
+  | `String x -> Ok (UserId x)
+  | _ -> Error "Couldn't parse user type"
 
 let bot_of_string s =
   if s.[0] = 'B' then BotId s else invalid_arg ("bot_of_string " ^ s)
 
 let bot_of_yojson = function
-  | `String x -> Result.Ok (bot_of_string x)
-  | _ -> Result.Error "Couldn't parse bot type"
+  | `String x -> Ok (bot_of_string x)
+  | _ -> Error "Couldn't parse bot type"
 
 
 let channel_of_yojson = function
-  | `String x -> Result.Ok (ChannelId x)
-  | _ -> Result.Error "Couldn't parse channel type"
+  | `String x -> Ok (ChannelId x)
+  | _ -> Error "Couldn't parse channel type"
 
 let group_of_yojson = function
-  | `String x -> Result.Ok (GroupId x)
-  | _ -> Result.Error "Couldn't parse group type"
+  | `String x -> Ok (GroupId x)
+  | _ -> Error "Couldn't parse group type"
 
 let conversation_of_yojson = function
-  | `String x -> Result.Ok x
-  | _ -> Result.Error "Couldn't parse conversation type"
+  | `String x -> Ok x
+  | _ -> Error "Couldn't parse conversation type"
 
 type topic_obj = {
   value: string;
@@ -439,11 +439,11 @@ type channel_rename_obj = {
 
 let chat_of_yojson = function
   | `String c -> (match c.[0] with
-    | 'C' -> Result.Ok (Channel (ChannelId c))
-    | 'D' -> Result.Ok (Im c)
-    | 'G' -> Result.Ok (Group (GroupId c))
-    | _ -> Result.Error "Failed to parse chat")
-  | _ -> Result.Error "Failed to parse chat"
+    | 'C' -> Ok (Channel (ChannelId c))
+    | 'D' -> Ok (Im c)
+    | 'G' -> Ok (Group (GroupId c))
+    | _ -> Error "Failed to parse chat")
+  | _ -> Error "Failed to parse chat"
 
 type chat_obj = {
   ts: Timestamp.t;
@@ -612,8 +612,8 @@ type api_answer = {
 
 let validate json =
   match api_answer_of_yojson json with
-  | Result.Error str -> `ParseFailure str
-  | Result.Ok parsed -> match parsed.ok, parsed.error with
+  | Error str -> `ParseFailure str
+  | Ok parsed -> match parsed.ok, parsed.error with
     | true, _ -> `Json_response json
     | _, Some "account_inactive" -> `Account_inactive
     | _, Some "already_archived" -> `Already_archived
@@ -741,8 +741,8 @@ let channels_list ?exclude_archived session =
     >|= function
     | `Json_response d ->
       (match d |> channels_list_obj_of_yojson with
-        | Result.Ok x -> `Success x.channels
-        | Result.Error x -> `ParseFailure x)
+        | Ok x -> `Success x.channels
+        | Error x -> `ParseFailure x)
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
@@ -752,8 +752,8 @@ let users_list session =
     >|= function
     | `Json_response d ->
       (match d |> users_list_obj_of_yojson with
-        | Result.Ok x -> `Success x.members
-        | Result.Error x -> `ParseFailure x)
+        | Ok x -> `Success x.members
+        | Error x -> `ParseFailure x)
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
@@ -764,8 +764,8 @@ let groups_list ?exclude_archived session =
     >|= function
     | `Json_response d ->
       (match d |> groups_list_obj_of_yojson with
-        | Result.Ok x -> `Success x.groups
-        | Result.Error x -> `ParseFailure x)
+        | Ok x -> `Success x.groups
+        | Error x -> `ParseFailure x)
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
@@ -886,8 +886,8 @@ let conversation_of_string s =
   if s.[0] = 'D' then s else failwith "Not an IM channel"
 
 let translate_parsing_error = function
-  | Result.Error a -> `ParseFailure a
-  | Result.Ok a -> `Success a
+  | Error a -> `ParseFailure a
+  | Ok a -> `Success a
 
 (* Slack API begins here *)
 
@@ -1201,8 +1201,8 @@ let emoji_list session =
     >|= function
     | `Json_response d ->
       (match d |> emoji_list_obj_of_yojson with
-      | Result.Ok x -> `Success x.emoji
-      | Result.Error x -> `ParseFailure x)
+      | Ok x -> `Success x.emoji
+      | Error x -> `ParseFailure x)
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 
@@ -1513,8 +1513,8 @@ let im_list session =
     >|= function
     | `Json_response d ->
       (match d |> im_list_obj_of_yojson with
-        | Result.Ok x -> `Success x.ims
-        | Result.Error x -> `ParseFailure x)
+        | Ok x -> `Success x.ims
+        | Error x -> `ParseFailure x)
     | #parsed_auth_error as res -> res
     | _ -> `Unknown_error
 

--- a/src/lib/timestamp.ml
+++ b/src/lib/timestamp.ml
@@ -67,7 +67,7 @@ let of_yojson json =
     | `String x -> of_string x
     | _ -> None
   with
-  | Some ts -> Result.Ok ts
-  | None -> Result.Error "Couldn't parse timestamp"
+  | Some ts -> Ok ts
+  | None -> Error "Couldn't parse timestamp"
 
 let to_yojson ts = `String (to_string ts)

--- a/test/abbrtypes.ml
+++ b/test/abbrtypes.ml
@@ -145,8 +145,8 @@ type abbr_user_obj_list = abbr_user_obj list
 
 let abbr_user_obj_list_of_yojson json =
   match abbr_users_list_obj_of_yojson json with
-  | Result.Ok obj -> Result.Ok obj.members
-  | (Result.Error _) as err -> err
+  | Ok obj -> Ok obj.members
+  | (Error _) as err -> err
 
 
 type abbr_file_obj = {


### PR DESCRIPTION
It is part of 4.08, no need for an additional dependency.