### PR TITLE
Replace `lwt_ppx` with `let`-syntax

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,8 +18,7 @@ those, upload and search files, manage presence.")
     (ocaml (>= 4.08))
     (cmdliner (>= 1.1.0))
     (yojson (>= 1.6.0))
-    (lwt (>= 3.2.0))
-    lwt_ppx
+    (lwt (>= 5.3.0))
     tls-lwt
     (cohttp-lwt-unix (>= 1.0.0))
     (ppx_deriving_yojson (>= 3.3))

--- a/slacko.opam
+++ b/slacko.opam
@@ -15,8 +15,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "cmdliner" {>= "1.1.0"}
   "yojson" {>= "1.6.0"}
-  "lwt" {>= "3.2.0"}
-  "lwt_ppx"
+  "lwt" {>= "5.3.0"}
   "tls-lwt"
   "cohttp-lwt-unix" {>= "1.0.0"}
   "ppx_deriving_yojson" {>= "3.3"}

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -4,4 +4,4 @@
   (synopsis "A neat interface for Slack")
   (private_modules Timestamp)
   (libraries lwt cohttp-lwt-unix yojson ppx_deriving_yojson.runtime ptime)
-  (preprocess (pps lwt_ppx ppx_deriving_yojson)))
+  (preprocess (pps ppx_deriving_yojson)))

--- a/src/lib/slacko.ml
+++ b/src/lib/slacko.ml
@@ -19,6 +19,7 @@
 *)
 
 open Lwt.Infix
+open Lwt.Syntax
 module Cohttp_unix = Cohttp_lwt_unix
 module Cohttp_body = Cohttp_lwt.Body
 
@@ -773,7 +774,8 @@ type 'a listfn = session -> [`Success of 'a list | parsed_auth_error] Lwt.t
 
 (* look up the id of query from results provided by the listfn *)
 let lookupk session (listfn : 'a listfn) filterfn k =
-  match%lwt listfn session with
+  let* v = listfn session in
+  match v with
   | #parsed_auth_error as e -> Lwt.return e
   | `Success items -> Lwt.return @@ k @@ List.filter filterfn items
 
@@ -911,7 +913,8 @@ let auth_test session =
 
 (* Operator for unwrapping channel_ids *)
 let (|->) m f =
-  match%lwt m with
+  let* m = m in
+  match m with
   | `Channel_not_found
   | #parsed_auth_error as e -> Lwt.return e
   | `User_not_found -> Lwt.return `Unknown_error
@@ -919,7 +922,8 @@ let (|->) m f =
 
 (* Operator for unwrapping user_ids *)
 let (|+>) m f =
-  match%lwt m with
+  let* m = m in
+  match m with
   | `Channel_not_found -> Lwt.return `Unknown_error
   | `User_not_found
   | #parsed_auth_error as e -> Lwt.return e


### PR DESCRIPTION
Given we depend on 4.08 anyway, might as well have one PPX less.