### PR TITLE
Replace OUnit2 with Alcotest

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -23,7 +23,8 @@ those, upload and search files, manage presence.")
     (cohttp-lwt-unix (>= 1.0.0))
     (ppx_deriving_yojson (>= 3.3))
     ptime
-    (ounit2 (and :with-test (>= 2.2)))
+    (alcotest :with-test)
+    (alcotest-lwt :with-test)
     (ppx_deriving (and :with-test (>= 5.2.1))))
   (conflicts
     ;; broken release: https://github.com/mirage/ocaml-conduit/issues/189

--- a/slacko.opam
+++ b/slacko.opam
@@ -20,7 +20,8 @@ depends: [
   "cohttp-lwt-unix" {>= "1.0.0"}
   "ppx_deriving_yojson" {>= "3.3"}
   "ptime"
-  "ounit2" {with-test & >= "2.2"}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
   "ppx_deriving" {with-test & >= "5.2.1"}
 ]
 conflicts: [

--- a/src/lib/timestamp.ml
+++ b/src/lib/timestamp.ml
@@ -32,6 +32,7 @@ let int64_pow b n =
 type t = Ptime.t
 
 let pp = Ptime.pp_human ~frac_s:6 ()
+let equal = Ptime.equal
 
 let of_string x =
   let d_ps_of_intlit intlit =

--- a/src/lib/timestamp.mli
+++ b/src/lib/timestamp.mli
@@ -24,3 +24,4 @@ val to_string : t -> string
 val of_yojson : Yojson.Safe.t -> (t, string) result
 val to_yojson : t -> Yojson.Safe.t
 val pp : Format.formatter -> t -> unit
+val equal : t -> t -> bool

--- a/test/abbrtypes.ml
+++ b/test/abbrtypes.ml
@@ -3,18 +3,13 @@
    those values at all. Therefore, we copy the record type that use these and
    skip the problematic fields. *)
 
-(* Wrap Yojson.Safe.t so we don't have to keep providing printers for it. *)
-type json = Yojson.Safe.t [@@deriving yojson]
-
-let pp_json fmt json = Format.pp_print_string fmt (Yojson.Safe.to_string json)
-
 type abbr_authed_obj = {
   url : string;
   team : string;
   user : string;
   team_id : string; (* user_id: user; *)
 }
-[@@deriving make, show, yojson { strict = false }]
+[@@deriving make, show, eq, yojson { strict = false }]
 
 let abbr_authed_obj (authed : Slacko.authed_obj) =
   {
@@ -29,7 +24,7 @@ type abbr_topic_obj = {
   (* creator: user; *)
   last_set : Timestamp.t;
 }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, eq, yojson { strict = false }]
 
 let abbr_topic_obj (topic : Slacko.topic_obj) =
   { value = topic.Slacko.value; last_set = topic.Slacko.last_set }
@@ -47,12 +42,12 @@ type abbr_channel_obj = {
   topic : abbr_topic_obj;
   purpose : abbr_topic_obj;
   last_read : Timestamp.t option; [@default None]
-  latest : json option; [@default None]
+  latest : Yojson.Safe.t option; [@default None]
   unread_count : int option; [@default None]
   unread_count_display : int option; [@default None]
   num_members : int option; [@default None]
 }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, eq, yojson { strict = false }]
 
 let abbr_channel_obj (chan : Slacko.channel_obj) =
   {
@@ -91,7 +86,7 @@ type abbr_conversation_obj = {
   unread_count_display : int option; [@default None]
   num_members : int option; [@default None]
 }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, eq, yojson { strict = false }]
 
 let abbr_conversation_obj (conversation : Slacko.conversation_obj) =
   {
@@ -109,10 +104,11 @@ let abbr_conversation_obj (conversation : Slacko.conversation_obj) =
     num_members = conversation.Slacko.num_members;
   }
 
-type abbr_conversation_obj_list = abbr_conversation_obj list [@@deriving show]
+type abbr_conversation_obj_list = abbr_conversation_obj list
+[@@deriving show, eq]
 
 type abbr_conversation_list_obj = { channels : abbr_conversation_obj list }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, eq, yojson { strict = false }]
 
 let abbr_conversation_obj_list_of_yojson json =
   match abbr_conversation_list_obj_of_yojson json with
@@ -126,7 +122,7 @@ type abbr_message_obj = {
   text : string option;
   is_starred : bool option; [@default None]
 }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, eq, yojson { strict = false }]
 
 let abbr_message_obj (message : Slacko.message_obj) =
   {
@@ -141,7 +137,7 @@ type abbr_history_obj = {
   messages : abbr_message_obj list;
   has_more : bool;
 }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, eq, yojson { strict = false }]
 
 let abbr_history_obj (history : Slacko.history_obj) =
   {
@@ -159,7 +155,7 @@ type abbr_user_obj = {
   tz : string option; [@default None]
   tz_label : string option; [@default None]
   tz_offset : int; [@default 0]
-  profile : json;
+  profile : Yojson.Safe.t;
   is_admin : bool; [@default false]
   is_owner : bool; [@default false]
   is_primary_owner : bool; [@default false]
@@ -168,7 +164,7 @@ type abbr_user_obj = {
   is_bot : bool;
   has_files : bool; [@default false]
 }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, eq, yojson { strict = false }]
 
 let abbr_user_obj (user : Slacko.user_obj) =
   {
@@ -192,7 +188,7 @@ let abbr_user_obj (user : Slacko.user_obj) =
 type abbr_users_list_obj = { members : abbr_user_obj list }
 [@@deriving of_yojson { strict = false }]
 
-type abbr_user_obj_list = abbr_user_obj list [@@deriving show]
+type abbr_user_obj_list = abbr_user_obj list [@@deriving show, eq]
 
 let abbr_user_obj_list_of_yojson json =
   match abbr_users_list_obj_of_yojson json with
@@ -236,10 +232,10 @@ type abbr_file_obj = {
   (* channels: channel list; *)
   (* groups: group list; *)
   (* ims: conversation list; *)
-  initial_comment : json option; [@default None]
+  initial_comment : Yojson.Safe.t option; [@default None]
   num_stars : int option; [@default None]
 }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, eq, yojson { strict = false }]
 
 let abbr_file_obj (file : Slacko.file_obj) =
   {
@@ -275,7 +271,7 @@ let abbr_file_obj (file : Slacko.file_obj) =
   }
 
 type abbr_paging_obj = { count : int; total : int; page : int; pages : int }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, eq, yojson { strict = false }]
 
 let abbr_paging_obj (paging : Slacko.paging_obj) =
   {
@@ -289,7 +285,7 @@ type abbr_files_list_obj = {
   files : abbr_file_obj list;
   paging : abbr_paging_obj;
 }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, eq, yojson { strict = false }]
 
 let abbr_files_list_obj (files : Slacko.files_list_obj) =
   {
@@ -311,9 +307,9 @@ type abbr_group_obj = {
   last_read : Timestamp.t option; [@default None]
   unread_count : int option; [@default None]
   unread_count_display : int option; [@default None]
-  latest : json option; [@default None]
+  latest : Yojson.Safe.t option; [@default None]
 }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, eq, yojson { strict = false }]
 
 let abbr_group_obj (group : Slacko.group_obj) =
   {
@@ -330,7 +326,7 @@ let abbr_group_obj (group : Slacko.group_obj) =
     latest = group.Slacko.latest;
   }
 
-type abbr_group_obj_list = abbr_group_obj list [@@deriving show, yojson]
+type abbr_group_obj_list = abbr_group_obj list [@@deriving show, eq, yojson]
 
 type abbr_im_obj = {
   id : string;
@@ -341,7 +337,7 @@ type abbr_im_obj = {
   unread_count : int option; [@default None]
   unread_count_display : int option; [@default None]
 }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, eq, yojson { strict = false }]
 
 let abbr_im_obj (im : Slacko.im_obj) =
   {
@@ -353,4 +349,4 @@ let abbr_im_obj (im : Slacko.im_obj) =
     unread_count_display = im.Slacko.unread_count_display;
   }
 
-type abbr_im_obj_list = abbr_im_obj list [@@deriving show, yojson]
+type abbr_im_obj_list = abbr_im_obj list [@@deriving show, eq, yojson]

--- a/test/dune
+++ b/test/dune
@@ -6,9 +6,10 @@
 
 (executable
  (name test_slacko)
- (libraries slacko ounit2)
+ (libraries slacko alcotest-lwt)
  (preprocess
-  (pps ppx_deriving_yojson ppx_deriving.std)))
+  (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.make
+    ppx_deriving.eq)))
 
 (rule
  (alias runtest)
@@ -17,4 +18,4 @@
    (file test_slacko.exe))
   (glob_files *.json))
  (action
-  (run %{test} -runner sequential)))
+  (run %{test})))

--- a/test/slounit.ml
+++ b/test/slounit.ml
@@ -1,8 +1,0 @@
-let lwt_test test_fun ctx = Lwt_main.run @@ test_fun ctx
-
-let fake_slack_test test_fun ctx =
-  lwt_test Fake_slack.with_fake_slack (fun () -> test_fun ctx)
-
-let fake_slack_tests label tests =
-  let open OUnit2 in
-  label >::: List.map (fun (l, f) -> l >:: fake_slack_test f) tests

--- a/test/test_slacko.ml
+++ b/test/test_slacko.ml
@@ -1,12 +1,11 @@
 open Lwt
-open OUnit2
-open Slounit
 open Abbrtypes
 
 let token =
   try Sys.getenv "SLACKO_TEST_TOKEN" with Not_found -> Fake_slack.valid_token
 
 let badtoken = "badtoken"
+let yojson = Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal
 
 (* If we have a non-default token, assume we want to talk to real slack. If
    not, use our local fake instead. *)
@@ -31,52 +30,101 @@ let abbr_json abbr_of_yojson json =
 
 let get_success = function
   | `Success obj -> obj
-  | _ -> assert_failure "Unexpected failure."
+  | _ -> Alcotest.fail "Unexpected failure."
 
 (* api_test *)
 
-let test_api_test_nodata _tctx =
+let test_api_test_nodata () =
   Slacko.api_test ?base_url () >|= get_success >|= fun json ->
-  assert_equal ~printer:Yojson.Safe.to_string (`Assoc []) json
+  Alcotest.(check yojson) "api.test empty" (`Assoc []) json
 
-let test_api_test_foo _tctx =
+let test_api_test_foo () =
   Slacko.api_test ?base_url ~foo:"hello" () >|= get_success >|= fun json ->
-  assert_equal ~printer:Yojson.Safe.to_string
+  Alcotest.(check yojson)
+    "api.test foo"
     (`Assoc [ ("args", `Assoc [ ("foo", `String "hello") ]) ])
     json
 
-let test_api_test_err _tctx =
-  Slacko.api_test ?base_url ~error:"badthing" () >|= fun resp ->
-  assert_equal (`Unhandled_error "badthing") resp
+type api_error = [ `Unhandled_error of string | `Unknown_error ]
+[@@deriving show, eq]
 
-let test_api_test_err_foo _tctx =
+type api_test = [ `Success of Yojson.Safe.t | api_error ] [@@deriving show, eq]
+
+let api_test = Alcotest.testable pp_api_test equal_api_test
+
+let test_api_test_err () =
+  Slacko.api_test ?base_url ~error:"badthing" () >|= fun resp ->
+  Alcotest.(check api_test) "error" (`Unhandled_error "badthing") resp
+
+let test_api_test_err_foo () =
   Slacko.api_test ?base_url ~foo:"goodbye" ~error:"badthing" () >|= fun resp ->
-  assert_equal (`Unhandled_error "badthing") resp
+  Alcotest.(check api_test) "error foo" (`Unhandled_error "badthing") resp
+
+let test_set ~label cases =
+  let open Alcotest_lwt in
+  let tests =
+    List.map
+      (fun (name, f) ->
+        test_case name `Quick (fun _sw () -> Fake_slack.with_fake_slack f))
+      cases
+  in
+  (label, tests)
 
 let api_test_tests =
-  fake_slack_tests "api_test"
+  test_set ~label:"api_test"
     [
-      ("test_nodata", test_api_test_nodata);
-      ("test_foo", test_api_test_foo);
-      ("test_err", test_api_test_err);
-      ("test_err_foo", test_api_test_err_foo);
+      ("nodata", test_api_test_nodata);
+      ("foo", test_api_test_foo);
+      ("err", test_api_test_err);
+      ("err_fooo", test_api_test_err_foo);
     ]
 
 (* auth_test *)
 
-let test_auth_test_valid _tctx =
+let abbr_authed_obj' =
+  Alcotest.testable pp_abbr_authed_obj equal_abbr_authed_obj
+
+let test_auth_test_valid () =
   let session = Slacko.start_session ?base_url token in
   Slacko.auth_test session >|= get_success >|= abbr_authed_obj >|= fun authed ->
-  assert_equal ~printer:show_abbr_authed_obj
+  Alcotest.(check abbr_authed_obj')
+    "valid"
     (abbr_json abbr_authed_obj_of_yojson Fake_slack.authed_json)
     authed
 
-let test_auth_test_invalid _tctx =
+type parsed_api_error = [ `ParseFailure of string | api_error ]
+[@@deriving show, eq]
+
+type auth_error = [ `Not_authed | `Invalid_auth | `Account_inactive ]
+[@@deriving show, eq]
+
+type parsed_auth_error = [ parsed_api_error | auth_error ] [@@deriving show, eq]
+type user = Slacko.user
+
+let pp_user ppf _v : unit = Fmt.pf ppf "TODO"
+let equal_user _ _ = true
+
+type authed_obj = Slacko.authed_obj = {
+  url : string;
+  team : string;
+  user : string;
+  team_id : string;
+  user_id : user;
+}
+[@@deriving show, eq]
+
+type auth_test = [ `Success of authed_obj | parsed_auth_error ]
+[@@deriving show, eq]
+
+let auth_test = Alcotest.testable pp_auth_test equal_auth_test
+
+let test_auth_test_invalid () =
   let session = Slacko.start_session ?base_url badtoken in
-  Slacko.auth_test session >|= fun resp -> assert_equal `Invalid_auth resp
+  Slacko.auth_test session >|= fun resp ->
+  Alcotest.(check auth_test) "invalid auth" `Invalid_auth resp
 
 let auth_test_tests =
-  fake_slack_tests "test_auth"
+  test_set ~label:"test_auth"
     [
       ("test_valid", test_auth_test_valid);
       ("test_invalid", test_auth_test_invalid);
@@ -84,38 +132,59 @@ let auth_test_tests =
 
 (* channels_archive  *)
 
-let test_channels_archive_bad_auth _tctx =
-  let session = Slacko.start_session ?base_url badtoken in
-  let new_channel = Slacko.channel_of_string "#new_channel" in
-  Slacko.channels_archive session new_channel >|= fun resp ->
-  assert_equal `Invalid_auth resp
+type channel_error = [ `Channel_not_found ] [@@deriving show, eq]
+type already_archived_error = [ `Already_archived ] [@@deriving show, eq]
+type restriction_error = [ `Restricted_action ] [@@deriving show, eq]
+type bot_error = [ `User_is_bot ] [@@deriving show, eq]
 
-let test_channels_archive_existing _tctx =
+type channels_archive =
+  [ `Success
+  | parsed_auth_error
+  | channel_error
+  | already_archived_error
+  | `Cant_archive_general
+  | `Last_restricted_channel
+  | restriction_error
+  | `User_is_restricted
+  | bot_error ]
+[@@deriving show, eq]
+
+let channels_archive =
+  Alcotest.testable pp_channels_archive equal_channels_archive
+
+let test_channels_archive_bad_auth () =
+  let session = Slacko.start_session ?base_url badtoken in
+  let new_channel = Slacko.channel_of_string "new_channel" in
+  Slacko.channels_archive session new_channel >|= fun resp ->
+  Alcotest.(check channels_archive) "bad auth" `Invalid_auth resp
+
+let test_channels_archive_existing () =
   let session = Slacko.start_session ?base_url token in
   let new_channel = Slacko.channel_of_string "archivable_channel" in
   Slacko.channels_archive session new_channel >|= fun resp ->
-  assert_equal `Success resp
+  Alcotest.(check channels_archive) "existing" `Success resp
 
-let test_channels_archive_missing _tctx =
+let test_channels_archive_missing () =
   let session = Slacko.start_session ?base_url token in
-  let missing_channel = Slacko.channel_of_string "#missing_channel" in
+  let missing_channel = Slacko.channel_of_string "missing_channel" in
   Slacko.channels_archive session missing_channel >|= fun resp ->
-  assert_equal `Channel_not_found resp
+  Alcotest.(check channels_archive) "not found" `Channel_not_found resp
 
-let test_channels_archive_archived _tctx =
+let test_channels_archive_archived () =
   let session = Slacko.start_session ?base_url token in
   let archived_channel = Slacko.channel_of_string "archived_channel" in
   Slacko.channels_archive session archived_channel >|= fun resp ->
-  assert_equal `Already_archived resp
+  Alcotest.(check channels_archive) "already archived" `Already_archived resp
 
-let test_channels_archive_general _tctx =
+let test_channels_archive_general () =
   let session = Slacko.start_session ?base_url token in
   let general = Slacko.channel_of_string "general" in
   Slacko.channels_archive session general >|= fun resp ->
-  assert_equal `Cant_archive_general resp
+  Alcotest.(check channels_archive)
+    "can't archive general" `Cant_archive_general resp
 
 let channels_archive_tests =
-  fake_slack_tests "channels_archive"
+  test_set ~label:"channels_archive"
     [
       ("test_bad_auth", test_channels_archive_bad_auth);
       ("test_existing", test_channels_archive_existing);
@@ -126,27 +195,76 @@ let channels_archive_tests =
 
 (* channels_create *)
 
-let test_channels_create_bad_auth _tctx =
-  let session = Slacko.start_session ?base_url badtoken in
-  Slacko.channels_create session "#new_channel" >|= fun resp ->
-  assert_equal `Invalid_auth resp
+type channel = Slacko.channel
 
-let test_channels_create_new _tctx =
+let pp_channel ppf _ = Fmt.pf ppf "TODO"
+let equal_channel _ _ = true
+
+type topic_obj = Slacko.topic_obj = {
+  value : string;
+  creator : user;
+  last_set : Timestamp.t;
+}
+[@@deriving show, eq]
+
+type channel_obj = Slacko.channel_obj = {
+  id : channel;
+  name : string;
+  is_channel : bool;
+  created : Timestamp.t;
+  creator : user;
+  is_archived : bool;
+  is_general : bool;
+  name_normalized : string;
+  is_member : bool;
+  members : user list;
+  topic : topic_obj;
+  purpose : topic_obj;
+  last_read : Timestamp.t option;
+  latest : Yojson.Safe.t option;
+  unread_count : int option;
+  unread_count_display : int option;
+  num_members : int option;
+}
+[@@deriving show, eq]
+
+type name_error = [ `Name_taken ] [@@deriving show, eq]
+
+type channels_create =
+  [ `Success of channel_obj
+  | parsed_auth_error
+  | name_error
+  | `User_is_restricted
+  | bot_error ]
+[@@deriving show, eq]
+
+let channels_create = Alcotest.testable pp_channels_create equal_channels_create
+
+let abbr_channel_obj' =
+  Alcotest.testable pp_abbr_channel_obj equal_abbr_channel_obj
+
+let test_channels_create_bad_auth () =
+  let session = Slacko.start_session ?base_url badtoken in
+  Slacko.channels_create session "new_channel" >|= fun resp ->
+  Alcotest.(check channels_create) "new channel bad auth" `Invalid_auth resp
+
+let test_channels_create_new () =
   let session = Slacko.start_session ?base_url token in
   Slacko.channels_create session "new_channel"
   >|= get_success >|= abbr_channel_obj
   >|= fun channel ->
-  assert_equal ~printer:show_abbr_channel_obj
+  Alcotest.(check abbr_channel_obj')
+    "new channel"
     (abbr_json abbr_channel_obj_of_yojson Fake_slack.new_channel_json)
     channel
 
-let test_channels_create_existing _tctx =
+let test_channels_create_existing () =
   let session = Slacko.start_session ?base_url token in
   Slacko.channels_create session "general" >|= fun resp ->
-  assert_equal `Name_taken resp
+  Alcotest.(check channels_create) "existing" `Name_taken resp
 
 let channels_create_tests =
-  fake_slack_tests "channels_create"
+  test_set ~label:"channels_create"
     [
       ("test_bad_auth", test_channels_create_bad_auth);
       ("test_new", test_channels_create_new);
@@ -155,22 +273,60 @@ let channels_create_tests =
 
 (* channels_history *)
 
-let test_channels_history_bad_auth _tctx =
-  let session = Slacko.start_session ?base_url badtoken in
-  let new_channel = Slacko.channel_of_string "#new_channel" in
-  Slacko.channels_history session new_channel >|= fun resp ->
-  assert_equal `Invalid_auth resp
+type bot = Slacko.bot
 
-let test_channels_history_no_params _tctx =
+let pp_bot ppf _ = Fmt.pf ppf "TODO"
+let equal_bot _ _ = true
+
+type message_obj = Slacko.message_obj = {
+  type' : string;
+  ts : Timestamp.t;
+  user : user option;
+  bot_id : bot option;
+  text : string option;
+  is_starred : bool option;
+}
+[@@deriving show, eq]
+
+type history_obj = Slacko.history_obj = {
+  latest : Timestamp.t option;
+  messages : message_obj list;
+  has_more : bool;
+}
+[@@deriving show, eq]
+
+type timestamp_error = [ `Invalid_ts_latest | `Invalid_ts_oldest ]
+[@@deriving show, eq]
+
+type history_result =
+  [ `Success of history_obj
+  | parsed_auth_error
+  | channel_error
+  | timestamp_error ]
+[@@deriving show, eq]
+
+let history_result = Alcotest.testable pp_history_result equal_history_result
+
+let abbr_history_obj' =
+  Alcotest.testable pp_abbr_history_obj equal_abbr_history_obj
+
+let test_channels_history_bad_auth () =
+  let session = Slacko.start_session ?base_url badtoken in
+  let new_channel = Slacko.channel_of_string "new_channel" in
+  Slacko.channels_history session new_channel >|= fun resp ->
+  Alcotest.(check history_result) "bad auth" `Invalid_auth resp
+
+let test_channels_history_no_params () =
   let session = Slacko.start_session ?base_url token in
   let random = Slacko.channel_of_string "random" in
   Slacko.channels_history session random >|= get_success >|= fun history ->
-  assert_equal ~printer:show_abbr_history_obj
+  Alcotest.(check abbr_history_obj')
+    "no params"
     (abbr_json abbr_history_obj_of_yojson Fake_slack.random_history_json)
     (abbr_history_obj history)
 
 let channels_history_tests =
-  fake_slack_tests "channels_history"
+  test_set ~label:"channels_history"
     [
       ("test_bad_auth", test_channels_history_bad_auth);
       ("test_no_params", test_channels_history_no_params);
@@ -181,27 +337,62 @@ let channels_history_tests =
 (* channels_join *)
 (* channels_kick *)
 (* channels_leave *)
+type conversation = Slacko.conversation
+
+let pp_conversation ppf _ = Fmt.pf ppf "TODO"
+let equal_conversation _ _ = true
 
 (* conversations_list *)
+type conversation_obj = Slacko.conversation_obj = {
+  id : conversation;
+  name : string;
+  is_channel : bool;
+  created : Timestamp.t;
+  creator : user;
+  is_archived : bool;
+  is_general : bool;
+  name_normalized : string;
+  is_member : bool;
+  topic : topic_obj;
+  purpose : topic_obj;
+  last_read : Timestamp.t option;
+  latest : string option;
+  unread_count : int option;
+  unread_count_display : int option;
+  num_members : int option;
+}
+[@@deriving show, eq]
 
-let test_conversations_list_bad_auth _tctx =
+type conversations_list =
+  [ `Success of conversation_obj list | parsed_auth_error ]
+[@@deriving show, eq]
+
+let conversations_list =
+  Alcotest.testable pp_conversations_list equal_conversations_list
+
+let test_conversations_list_bad_auth () =
   let session = Slacko.start_session ?base_url badtoken in
   Slacko.conversations_list session >|= fun resp ->
-  assert_equal `Invalid_auth resp
+  Alcotest.(check conversations_list) "bad auth" `Invalid_auth resp
 
-let test_conversations_list _tctx =
+let abbr_conversation_obj_list' =
+  Alcotest.testable pp_abbr_conversation_obj_list
+    equal_abbr_conversation_obj_list
+
+let test_conversations_list () =
   let session = Slacko.start_session ?base_url token in
   Slacko.conversations_list session
   >|= get_success
   >|= List.map abbr_conversation_obj
   >|= fun conversations ->
-  assert_equal ~printer:show_abbr_conversation_obj_list
+  Alcotest.(check abbr_conversation_obj_list')
+    "test"
     (abbr_json abbr_conversation_obj_list_of_yojson
        Fake_slack.conversations_json)
     conversations
 
 let conversations_list_tests =
-  fake_slack_tests "conversations_list"
+  test_set ~label:"conversations_list"
     [
       ("test_bad_auth", test_conversations_list_bad_auth);
       ("test", test_conversations_list);
@@ -220,21 +411,99 @@ let conversations_list_tests =
 (* files_info *)
 
 (* files_list *)
+type group = Slacko.group
 
-let test_files_list_bad_auth _tctx =
+let pp_group ppf _ = Fmt.pf ppf "TODO"
+let equal_group _ _ = true
+
+type im = Slacko.im
+
+let pp_im ppf _ = Fmt.pf ppf "TODO"
+let equal_im _ _ = true
+
+type file_obj = Slacko.file_obj = {
+  id : string;
+  created : Timestamp.t;
+  timestamp : Timestamp.t;
+  name : string option;
+  title : string;
+  mimetype : string;
+  pretty_type : string;
+  user : user;
+  mode : string;
+  editable : bool;
+  is_external : bool;
+  external_type : string;
+  size : int;
+  url_private : string;
+  url_private_download : string;
+  thumb_64 : string option;
+  thunb_80 : string option;
+  thumb_360 : string option;
+  thumb_360_gif : string option;
+  thumb_360_w : int option;
+  thumb_360_h : int option;
+  permalink : string;
+  edit_link : string option;
+  preview : string option;
+  preview_highlight : string option;
+  lines : int option;
+  lines_more : int option;
+  is_public : bool;
+  channels : channel list;
+  groups : group list;
+  ims : im list;
+  initial_comment : Yojson.Safe.t option;
+  num_stars : int option;
+}
+[@@deriving show, eq]
+
+type paging_obj = Slacko.paging_obj = {
+  count : int;
+  total : int;
+  page : int;
+  pages : int;
+}
+[@@deriving show, eq]
+
+type files_list_obj = Slacko.files_list_obj = {
+  files : file_obj list;
+  paging : paging_obj;
+}
+[@@deriving show, eq]
+
+type user_error = [ `User_not_found ] [@@deriving show, eq]
+type unknown_type_error = [ `Unknown_type ] [@@deriving show, eq]
+
+type files_list =
+  [ `Success of files_list_obj
+  | parsed_auth_error
+  | user_error
+  | unknown_type_error
+  | bot_error ]
+[@@deriving show, eq]
+
+let files_list = Alcotest.testable pp_files_list equal_files_list
+
+let test_files_list_bad_auth () =
   let session = Slacko.start_session ?base_url badtoken in
-  Slacko.files_list session >|= fun resp -> assert_equal `Invalid_auth resp
+  Slacko.files_list session >|= fun resp ->
+  Alcotest.(check files_list) "bad auth" `Invalid_auth resp
 
-let test_files_list _tctx =
+let abbr_files_list_obj' =
+  Alcotest.testable pp_abbr_files_list_obj equal_abbr_files_list_obj
+
+let test_files_list () =
   let session = Slacko.start_session ?base_url token in
   Slacko.files_list session >|= get_success >|= abbr_files_list_obj
   >|= fun files ->
-  assert_equal ~printer:show_abbr_files_list_obj
+  Alcotest.(check abbr_files_list_obj')
+    "test"
     (abbr_json abbr_files_list_obj_of_yojson Fake_slack.files_json)
     files
 
 let files_list_tests =
-  fake_slack_tests "files_list"
+  test_set ~label:"files_list"
     [ ("test_bad_auth", test_files_list_bad_auth); ("test", test_files_list) ]
 
 (* files_upload *)
@@ -245,22 +514,23 @@ let files_list_tests =
 
 (* groups_history *)
 
-let test_groups_history_bad_auth _tctx =
+let test_groups_history_bad_auth () =
   let session = Slacko.start_session ?base_url badtoken in
   let seekrit = Slacko.group_of_string "seekrit" in
   Slacko.groups_history session seekrit >|= fun resp ->
-  assert_equal `Invalid_auth resp
+  Alcotest.(check history_result) "bad auth" `Invalid_auth resp
 
-let test_groups_history_no_params _tctx =
+let test_groups_history_no_params () =
   let session = Slacko.start_session ?base_url token in
   let seekrit = Slacko.group_of_string "seekrit" in
   Slacko.groups_history session seekrit >|= get_success >|= fun history ->
-  assert_equal ~printer:show_abbr_history_obj
+  Alcotest.(check abbr_history_obj')
+    "no params"
     (abbr_json abbr_history_obj_of_yojson Fake_slack.seekrit_history_json)
     (abbr_history_obj history)
 
 let groups_history_tests =
-  fake_slack_tests "groups_history"
+  test_set ~label:"groups_history"
     [
       ("test_bad_auth", test_groups_history_bad_auth);
       ("test_no_params", test_groups_history_no_params);
@@ -271,21 +541,48 @@ let groups_history_tests =
 (* groups_leave *)
 
 (* groups_list *)
+type group_obj = Slacko.group_obj = {
+  id : group;
+  name : string;
+  is_group : bool;
+  created : Timestamp.t;
+  creator : user;
+  is_archived : bool;
+  members : user list;
+  topic : topic_obj;
+  purpose : topic_obj;
+  is_open : bool option;
+  last_read : Timestamp.t option;
+  unread_count : int option;
+  unread_count_display : int option;
+  latest : Yojson.Safe.t option;
+}
+[@@deriving show, eq]
 
-let test_groups_list_bad_auth _tctx =
+type groups_list = [ `Success of group_obj list | parsed_auth_error ]
+[@@deriving show, eq]
+
+let groups_list = Alcotest.testable pp_groups_list equal_groups_list
+
+let test_groups_list_bad_auth () =
   let session = Slacko.start_session ?base_url badtoken in
-  Slacko.groups_list session >|= fun resp -> assert_equal `Invalid_auth resp
+  Slacko.groups_list session >|= fun resp ->
+  Alcotest.(check groups_list) "bad auth" `Invalid_auth resp
 
-let test_groups_list _tctx =
+let abbr_group_obj_list =
+  Alcotest.testable pp_abbr_group_obj_list equal_abbr_group_obj_list
+
+let test_groups_list () =
   let session = Slacko.start_session ?base_url token in
   Slacko.groups_list session >|= get_success >|= List.map abbr_group_obj
   >|= fun groups ->
-  assert_equal ~printer:show_abbr_group_obj_list
+  Alcotest.(check abbr_group_obj_list)
+    "test"
     (abbr_json abbr_group_obj_list_of_yojson Fake_slack.groups_json)
     groups
 
 let groups_list_tests =
-  fake_slack_tests "groups_list"
+  test_set ~label:"groups_list"
     [ ("test_bad_auth", test_groups_list_bad_auth); ("test", test_groups_list) ]
 
 (* groups_mark *)
@@ -298,22 +595,23 @@ let groups_list_tests =
 
 (* im_history *)
 
-let test_im_history_bad_auth _tctx =
+let test_im_history_bad_auth () =
   let session = Slacko.start_session ?base_url badtoken in
   let slackbot = Slacko.im_of_string Fake_slack.im_slackbot in
   Slacko.im_history session slackbot >|= fun resp ->
-  assert_equal `Invalid_auth resp
+  Alcotest.(check history_result) "bad auth" `Invalid_auth resp
 
-let test_im_history_no_params _tctx =
+let test_im_history_no_params () =
   let session = Slacko.start_session ?base_url token in
   let slackbot = Slacko.im_of_string Fake_slack.im_slackbot in
   Slacko.im_history session slackbot >|= get_success >|= fun history ->
-  assert_equal ~printer:show_abbr_history_obj
+  Alcotest.(check abbr_history_obj')
+    "no params"
     (abbr_json abbr_history_obj_of_yojson Fake_slack.slackbot_history_json)
     (abbr_history_obj history)
 
 let im_history_tests =
-  fake_slack_tests "im_history"
+  test_set ~label:"im_history"
     [
       ("test_bad_auth", test_im_history_bad_auth);
       ("test_no_params", test_im_history_no_params);
@@ -321,19 +619,41 @@ let im_history_tests =
 
 (* im_list *)
 
-let test_im_list_bad_auth _tctx =
-  let session = Slacko.start_session ?base_url badtoken in
-  Slacko.im_list session >|= fun resp -> assert_equal `Invalid_auth resp
+type im_obj = Slacko.im_obj = {
+  id : string;
+  is_im : bool;
+  user : user;
+  created : Timestamp.t;
+  is_user_deleted : bool;
+  is_open : bool option;
+  last_read : Timestamp.t option;
+  unread_count : int option;
+  unread_count_display : int option;
+}
+[@@deriving show, eq]
 
-let test_im_list _tctx =
+type im_list = [ `Success of im_obj list | parsed_auth_error ]
+[@@deriving show, eq]
+
+let im_list = Alcotest.testable pp_im_list equal_im_list
+
+let test_im_list_bad_auth () =
+  let session = Slacko.start_session ?base_url badtoken in
+  Slacko.im_list session >|= fun resp ->
+  Alcotest.(check im_list) "bad auth" `Invalid_auth resp
+
+let abbr_im_obj_list' =
+  Alcotest.testable pp_abbr_im_obj_list equal_abbr_im_obj_list
+
+let test_im_list () =
   let session = Slacko.start_session ?base_url token in
   Slacko.im_list session >|= get_success >|= List.map abbr_im_obj >|= fun ims ->
-  assert_equal ~printer:show_abbr_im_obj_list
+  Alcotest.check abbr_im_obj_list' "test"
     (abbr_json abbr_im_obj_list_of_yojson Fake_slack.ims_json)
     ims
 
 let im_list_tests =
-  fake_slack_tests "im_list"
+  test_set ~label:"im_list"
     [ ("test_bad_auth", test_im_list_bad_auth); ("test", test_im_list) ]
 
 (* im_mark *)
@@ -350,20 +670,49 @@ let im_list_tests =
 
 (* users_list *)
 
-let test_users_list_bad_auth _tctx =
-  let session = Slacko.start_session ?base_url badtoken in
-  Slacko.users_list session >|= fun resp -> assert_equal `Invalid_auth resp
+type user_obj = Slacko.user_obj = {
+  id : user;
+  name : string;
+  deleted : bool;
+  color : string option;
+  real_name : string option;
+  tz : string option;
+  tz_label : string option;
+  tz_offset : int;
+  profile : Yojson.Safe.t;
+  is_admin : bool;
+  is_owner : bool;
+  is_primary_owner : bool;
+  is_restricted : bool;
+  is_ultra_restricted : bool;
+  is_bot : bool;
+  has_files : bool;
+}
+[@@deriving show, eq]
 
-let test_users_list _tctx =
+type users_list = [ `Success of user_obj list | parsed_auth_error ]
+[@@deriving show, eq]
+
+let users_list = Alcotest.testable pp_users_list equal_users_list
+
+let test_users_list_bad_auth () =
+  let session = Slacko.start_session ?base_url badtoken in
+  Slacko.users_list session >|= fun resp ->
+  Alcotest.check users_list "bad auth" `Invalid_auth resp
+
+let abbr_user_obj_list =
+  Alcotest.testable pp_abbr_user_obj_list equal_abbr_user_obj_list
+
+let test_users_list () =
   let session = Slacko.start_session ?base_url token in
   Slacko.users_list session >|= get_success >|= List.map abbr_user_obj
   >|= fun users ->
-  assert_equal ~printer:show_abbr_user_obj_list
+  Alcotest.check abbr_user_obj_list "test"
     (abbr_json abbr_user_obj_list_of_yojson Fake_slack.users_json)
     users
 
 let users_list_tests =
-  fake_slack_tests "users_list"
+  test_set ~label:"users_list"
     [ ("test_bad_auth", test_users_list_bad_auth); ("test", test_users_list) ]
 
 (* users_set_active *)
@@ -372,64 +721,65 @@ let users_list_tests =
 (* Gotta run them all! *)
 
 let suite =
-  "tests"
-  >::: [
-         api_test_tests;
-         auth_test_tests;
-         channels_archive_tests;
-         channels_create_tests;
-         channels_history_tests;
-         (* channels_info_tests; *)
-         (* channels_invite_tests; *)
-         (* channels_join_tests; *)
-         (* channels_kick_tests; *)
-         (* channels_leave_tests; *)
-         conversations_list_tests;
-         (* channels_mark_tests; *)
-         (* channels_rename_tests; *)
-         (* channels_set_purpose_tests; *)
-         (* channels_set_topic_tests; *)
-         (* channels_unarchive_tests; *)
-         (* chat_delete_tests; *)
-         (* chat_post_message_tests; *)
-         (* chat_update_tests; *)
-         (* emoji_list_tests; *)
-         (* files_delete_tests; *)
-         (* files_info_tests; *)
-         files_list_tests;
-         (* files_upload_tests; *)
-         (* groups_archive_tests; *)
-         (* groups_close_tests; *)
-         (* groups_create_tests; *)
-         (* groups_create_child_tests; *)
-         groups_history_tests;
-         (* groups_invite_tests; *)
-         (* groups_kick_tests; *)
-         (* groups_leave_tests; *)
-         groups_list_tests;
-         (* groups_mark_tests; *)
-         (* groups_open_tests; *)
-         (* groups_rename_tests; *)
-         (* groups_set_purpose_tests; *)
-         (* groups_set_topic_tests; *)
-         (* groups_unarchive_tests; *)
-         (* im_close_tests; *)
-         im_history_tests;
-         im_list_tests;
-         (* im_mark_tests; *)
-         (* im_open_tests; *)
-         (* oauth_access_tests; *)
-         (* search_all_tests; *)
-         (* search_files_tests; *)
-         (* search_messages_tests; *)
-         (* stars_list_tests; *)
-         (* team_access_logs_tests; *)
-         (* team_info_tests; *)
-         (* users_get_presence_tests; *)
-         (* users_info_tests; *)
-         users_list_tests;
-         (* users_set_active_tests; *)
-         (* users_set_presence_tests; *)
-       ]
+  let open Alcotest_lwt in
+  run "tests"
+    [
+      api_test_tests;
+      auth_test_tests;
+      channels_archive_tests;
+      channels_create_tests;
+      channels_history_tests;
+      (* channels_info_tests; *)
+      (* channels_invite_tests; *)
+      (* channels_join_tests; *)
+      (* channels_kick_tests; *)
+      (* channels_leave_tests; *)
+      conversations_list_tests;
+      (* channels_mark_tests; *)
+      (* channels_rename_tests; *)
+      (* channels_set_purpose_tests; *)
+      (* channels_set_topic_tests; *)
+      (* channels_unarchive_tests; *)
+      (* chat_delete_tests; *)
+      (* chat_post_message_tests; *)
+      (* chat_update_tests; *)
+      (* emoji_list_tests; *)
+      (* files_delete_tests; *)
+      (* files_info_tests; *)
+      files_list_tests;
+      (* files_upload_tests; *)
+      (* groups_archive_tests; *)
+      (* groups_close_tests; *)
+      (* groups_create_tests; *)
+      (* groups_create_child_tests; *)
+      groups_history_tests;
+      (* groups_invite_tests; *)
+      (* groups_kick_tests; *)
+      (* groups_leave_tests; *)
+      groups_list_tests;
+      (* groups_mark_tests; *)
+      (* groups_open_tests; *)
+      (* groups_rename_tests; *)
+      (* groups_set_purpose_tests; *)
+      (* groups_set_topic_tests; *)
+      (* groups_unarchive_tests; *)
+      (* im_close_tests; *)
+      im_history_tests;
+      im_list_tests;
+      (* im_mark_tests; *)
+      (* im_open_tests; *)
+      (* oauth_access_tests; *)
+      (* search_all_tests; *)
+      (* search_files_tests; *)
+      (* search_messages_tests; *)
+      (* stars_list_tests; *)
+      (* team_access_logs_tests; *)
+      (* team_info_tests; *)
+      (* users_get_presence_tests; *)
+      (* users_info_tests; *)
+      users_list_tests;
+      (* users_set_active_tests; *)
+      (* users_set_presence_tests; *)
+    ]
 
-let () = run_test_tt_main suite
+let () = Lwt_main.run suite


### PR DESCRIPTION
This PR refactors the test framework to avoid polymorphic comparison

 * [X] remote `ounit2`
 * [X] make tests pass
 * [ ] remove Abbrtypes, use the real types
 * [ ] fix all the broken printers/equal functions
 * [ ] Unify `timestamp` by using a module